### PR TITLE
Refatora DSL de testes para uso automático de fixture

### DIFF
--- a/src/XUnitAssured.Core/Abstractions/IHttpClientProvider.cs
+++ b/src/XUnitAssured.Core/Abstractions/IHttpClientProvider.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+
+namespace XUnitAssured.Core.Abstractions;
+
+/// <summary>
+/// Interface for test fixtures that provide HttpClient instances.
+/// Implementing this interface allows fixtures to be used directly with Given() overload.
+/// </summary>
+/// <example>
+/// <code>
+/// public class MyTestFixture : IHttpClientProvider
+/// {
+///     private readonly WebApplicationFactory&lt;Program&gt; _factory;
+///     
+///     public HttpClient CreateClient() => _factory.CreateClient();
+/// }
+/// 
+/// // In tests:
+/// Given(_fixture)
+///     .ApiResource("/api/endpoint")
+///     .Get()
+/// </code>
+/// </example>
+public interface IHttpClientProvider
+{
+	/// <summary>
+	/// Creates an HttpClient instance for testing.
+	/// </summary>
+	/// <returns>A configured HttpClient instance</returns>
+	HttpClient CreateClient();
+}

--- a/src/XUnitAssured.Core/DSL/ScenarioDsl.cs
+++ b/src/XUnitAssured.Core/DSL/ScenarioDsl.cs
@@ -28,4 +28,37 @@ public static class ScenarioDsl
 	{
 		return new TestScenario(context);
 	}
+
+	/// <summary>
+	/// Starts a new test scenario with an HttpClient provider (e.g., test fixture).
+	/// Automatically configures the scenario to use the HttpClient from the provider.
+	/// </summary>
+	/// <param name="httpClientProvider">Provider that supplies HttpClient instances (e.g., WebApplicationFactory fixture)</param>
+	/// <returns>A new test scenario pre-configured with the HttpClient</returns>
+	/// <example>
+	/// <code>
+	/// // Traditional way:
+	/// Given()
+	///     .WithHttpClient(_fixture.CreateClient())
+	///     .ApiResource("/api/products")
+	///     .Get()
+	/// 
+	/// // Simplified way with this overload:
+	/// Given(_fixture)
+	///     .ApiResource("/api/products")
+	///     .Get()
+	/// </code>
+	/// </example>
+	public static ITestScenario Given(IHttpClientProvider httpClientProvider)
+	{
+		if (httpClientProvider == null)
+			throw new System.ArgumentNullException(nameof(httpClientProvider));
+
+		var scenario = new TestScenario();
+		
+		// Store the HttpClient provider in the context for later use
+		scenario.Context.SetProperty("HttpClientProvider", httpClientProvider);
+		
+		return scenario;
+	}
 }

--- a/src/XUnitAssured.Core/Testing/FixtureTestBase.cs
+++ b/src/XUnitAssured.Core/Testing/FixtureTestBase.cs
@@ -1,0 +1,75 @@
+using System;
+using XUnitAssured.Core.Abstractions;
+using XUnitAssured.Core.DSL;
+
+namespace XUnitAssured.Core.Testing;
+
+/// <summary>
+/// Generic abstract base class for integration tests using XUnitAssured with any fixture type.
+/// Provides a clean Given() method that automatically uses the injected fixture.
+/// This class is technology-agnostic and can be used with HTTP, Kafka, FileSystem, S3, or any other fixture type.
+/// </summary>
+/// <typeparam name="TFixture">The fixture type to be injected via xUnit's IClassFixture</typeparam>
+/// <example>
+/// <code>
+/// // Example with HTTP fixture
+/// public class MyApiTests : FixtureTestBase&lt;HttpTestFixture&gt;, IClassFixture&lt;HttpTestFixture&gt;
+/// {
+///     public MyApiTests(HttpTestFixture fixture) : base(fixture) { }
+/// }
+/// 
+/// // Example with Kafka fixture
+/// public class MyKafkaTests : FixtureTestBase&lt;KafkaTestFixture&gt;, IClassFixture&lt;KafkaTestFixture&gt;
+/// {
+///     public MyKafkaTests(KafkaTestFixture fixture) : base(fixture) { }
+/// }
+/// </code>
+/// </example>
+public abstract class FixtureTestBase<TFixture>
+{
+	/// <summary>
+	/// The test fixture instance injected via xUnit's IClassFixture.
+	/// </summary>
+	protected TFixture Fixture { get; }
+
+	/// <summary>
+	/// Initializes a new instance of the FixtureTestBase class.
+	/// </summary>
+	/// <param name="fixture">The test fixture</param>
+	protected FixtureTestBase(TFixture fixture)
+	{
+		Fixture = fixture ?? throw new ArgumentNullException(nameof(fixture));
+	}
+
+	/// <summary>
+	/// Starts a new test scenario.
+	/// This is the standard entry point for the fluent DSL without fixture integration.
+	/// </summary>
+	/// <returns>A new test scenario</returns>
+	/// <example>
+	/// <code>
+	/// Given()
+	///     .ApiResource("/api/products")
+	///     .Get()
+	///     .When()
+	///         .Execute()
+	///     .Then()
+	///         .AssertStatusCode(200);
+	/// </code>
+	/// </example>
+	protected ITestScenario Given()
+	{
+		return ScenarioDsl.Given();
+	}
+
+	/// <summary>
+	/// Starts a new test scenario with a custom context.
+	/// Use this when you need to provide a specific test context.
+	/// </summary>
+	/// <param name="context">Custom test context</param>
+	/// <returns>A new test scenario with the specified context</returns>
+	protected ITestScenario Given(ITestContext context)
+	{
+		return ScenarioDsl.Given(context);
+	}
+}

--- a/src/XUnitAssured.Http.Samples.Test/ApiKeyAuthTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/ApiKeyAuthTests.cs
@@ -1,36 +1,31 @@
 using XUnitAssured.Extensions.Http;
 using XUnitAssured.Http.Configuration;
 using XUnitAssured.Http.Extensions;
-
-using static XUnitAssured.Core.DSL.ScenarioDsl;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Authentication", "ApiKey")]
 /// <summary>
 /// Sample tests demonstrating API Key Authentication using XUnitAssured.Http.
 /// API Keys can be sent in HTTP headers or query parameters.
 /// </summary>
-public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
+public class ApiKeyAuthTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public ApiKeyAuthTests(HttpSamplesFixture fixture)
+	public ApiKeyAuthTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
 	#region Header-based API Key Tests
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Header with valid key should return success")]
 	public void Example01_ApiKeyHeader_WithValidKey_ShouldReturnSuccess()
 	{
 		// Arrange
 		var validApiKey = "api-key-header-abc123xyz";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", validApiKey, ApiKeyLocation.Header)
 			.Get()
 		.When()
@@ -42,16 +37,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.message", value => value?.Contains("successful") == true, "Should return success message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Header with invalid key should return 401 Unauthorized")]
 	public void Example02_ApiKeyHeader_WithInvalidKey_ShouldReturn401()
 	{
 		// Arrange
 		var invalidApiKey = "invalid-api-key";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", invalidApiKey, ApiKeyLocation.Header)
 			.Get()
 		.When()
@@ -61,13 +54,11 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Header without key should return 401 Unauthorized")]
 	public void Example03_ApiKeyHeader_WithoutKey_ShouldReturn401()
 	{
 		// Act & Assert - No API key provided
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.Get()
 		.When()
 			.Execute()
@@ -76,16 +67,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Header with empty key should return 401 Unauthorized")]
 	public void Example04_ApiKeyHeader_WithEmptyKey_ShouldReturn401()
 	{
 		// Arrange
 		var emptyApiKey = "";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", emptyApiKey, ApiKeyLocation.Header)
 			.Get()
 		.When()
@@ -94,16 +83,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Header is case-sensitive and wrong case should return 401 Unauthorized")]
 	public void Example05_ApiKeyHeader_KeyIsCaseSensitive_ShouldReturn401()
 	{
 		// Arrange - API key is case-sensitive
 		var wrongCaseKey = "API-KEY-HEADER-ABC123XYZ"; // Wrong case
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", wrongCaseKey, ApiKeyLocation.Header)
 			.Get()
 		.When()
@@ -113,16 +100,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key default location should be Header when not specified")]
 	public void Example06_ApiKeyHeader_DefaultLocationIsHeader()
 	{
 		// Arrange
 		var validApiKey = "api-key-header-abc123xyz";
 
 		// Act & Assert - Default location is Header when not specified
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", validApiKey) // No location specified = Header by default
 			.Get()
 		.When()
@@ -136,16 +121,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 
 	#region Query Parameter-based API Key Tests
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Query Parameter with valid key should return success")]
 	public void Example07_ApiKeyQuery_WithValidKey_ShouldReturnSuccess()
 	{
 		// Arrange
 		var validApiKey = "api-key-query-xyz789abc";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-query")
+		Given().ApiResource("/api/auth/apikey-query")
 			.WithApiKey("api_key", validApiKey, ApiKeyLocation.Query)
 			.Get()
 		.When()
@@ -157,16 +140,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.message", value => value?.Contains("successful") == true, "Should return success message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Query Parameter with invalid key should return 401 Unauthorized")]
 	public void Example08_ApiKeyQuery_WithInvalidKey_ShouldReturn401()
 	{
 		// Arrange
 		var invalidApiKey = "invalid-query-key";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-query")
+		Given().ApiResource("/api/auth/apikey-query")
 			.WithApiKey("api_key", invalidApiKey, ApiKeyLocation.Query)
 			.Get()
 		.When()
@@ -176,13 +157,11 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Query Parameter without key should return 401 Unauthorized")]
 	public void Example09_ApiKeyQuery_WithoutKey_ShouldReturn401()
 	{
 		// Act & Assert - No API key in query parameter
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-query")
+		Given().ApiResource("/api/auth/apikey-query")
 			.Get()
 		.When()
 			.Execute()
@@ -191,16 +170,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Query Parameter with empty key should return 401 Unauthorized")]
 	public void Example10_ApiKeyQuery_WithEmptyKey_ShouldReturn401()
 	{
 		// Arrange
 		var emptyApiKey = "";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-query")
+		Given().ApiResource("/api/auth/apikey-query")
 			.WithApiKey("api_key", emptyApiKey, ApiKeyLocation.Query)
 			.Get()
 		.When()
@@ -209,16 +186,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Query Parameter is case-sensitive and wrong case should return 401 Unauthorized")]
 	public void Example11_ApiKeyQuery_KeyIsCaseSensitive_ShouldReturn401()
 	{
 		// Arrange - API key is case-sensitive
 		var wrongCaseKey = "API-KEY-QUERY-XYZ789ABC"; // Wrong case
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-query")
+		Given().ApiResource("/api/auth/apikey-query")
 			.WithApiKey("api_key", wrongCaseKey, ApiKeyLocation.Query)
 			.Get()
 		.When()
@@ -232,7 +207,7 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 
 	#region Comparison and Mixed Scenarios
 
-	[Fact]
+	[Fact(DisplayName = "API Key in Header and Query Parameter are different endpoints")]
 	public void Example12_ApiKey_HeaderAndQueryAreDifferent()
 	{
 		// Demonstrate that header and query API keys are different endpoints
@@ -244,9 +219,7 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 		var queryKey = "api-key-query-xyz789abc";
 
 		// Act & Assert - Header key works on header endpoint
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", headerKey, ApiKeyLocation.Header)
 			.Get()
 		.When()
@@ -256,9 +229,7 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.authType", value => value == "ApiKey-Header", "Should authenticate with header key");
 
 		// Act & Assert - Query key works on query endpoint
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-query")
+		Given().ApiResource("/api/auth/apikey-query")
 			.WithApiKey("api_key", queryKey, ApiKeyLocation.Query)
 			.Get()
 		.When()
@@ -268,16 +239,14 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.authType", value => value == "ApiKey-Query", "Should authenticate with query key");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "API Key should work across multiple requests with same key")]
 	public void Example13_ApiKey_MultipleRequestsWithSameKey()
 	{
 		// Arrange
 		var validHeaderKey = "api-key-header-abc123xyz";
 
 		// Act & Assert - First request
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", validHeaderKey, ApiKeyLocation.Header)
 			.Get()
 		.When()
@@ -287,9 +256,7 @@ public class ApiKeyAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "First request should be authenticated");
 
 		// Act & Assert - Second request with same key
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/apikey-header")
+		Given().ApiResource("/api/auth/apikey-header")
 			.WithApiKey("X-API-Key", validHeaderKey, ApiKeyLocation.Header)
 			.Get()
 		.When()

--- a/src/XUnitAssured.Http.Samples.Test/BasicAuthTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/BasicAuthTests.cs
@@ -1,24 +1,21 @@
 using XUnitAssured.Extensions.Http;
 using XUnitAssured.Http.Extensions;
-
-using static XUnitAssured.Core.DSL.ScenarioDsl;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Authentication", "Basic")]
 /// <summary>
 /// Sample tests demonstrating Basic Authentication using XUnitAssured.Http.
 /// Basic Auth sends credentials as base64-encoded "username:password" in the Authorization header.
 /// </summary>
-public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
+public class BasicAuthTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public BasicAuthTests(HttpSamplesFixture fixture)
+	public BasicAuthTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with valid credentials should return success")]
 	public void Example01_BasicAuth_WithValidCredentials_ShouldReturnSuccess()
 	{
 		// Arrange
@@ -27,7 +24,6 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, password)
 			.Get()
@@ -41,7 +37,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.message", value => value?.Contains("successful") == true, "Should return success message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with invalid credentials should return 401 Unauthorized")]
 	public void Example02_BasicAuth_WithInvalidCredentials_ShouldReturn401()
 	{
 		// Arrange
@@ -49,9 +45,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var wrongPassword = "wrongpassword";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, wrongPassword)
 			.Get()
 		.When()
@@ -60,7 +54,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with invalid username should return 401 Unauthorized")]
 	public void Example03_BasicAuth_WithInvalidUsername_ShouldReturn401()
 	{
 		// Arrange
@@ -68,9 +62,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var password = "secret123";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(wrongUsername, password)
 			.Get()
 		.When()
@@ -79,13 +71,11 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication without credentials should return 401 Unauthorized")]
 	public void Example04_BasicAuth_WithoutCredentials_ShouldReturn401()
 	{
 		// Act & Assert - No authentication provided
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.Get()
 		.When()
 			.Execute()
@@ -93,7 +83,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with empty username should return 401 Unauthorized")]
 	public void Example05_BasicAuth_WithEmptyUsername_ShouldReturn401()
 	{
 		// Arrange
@@ -101,9 +91,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var password = "secret123";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(emptyUsername, password)
 			.Get()
 		.When()
@@ -112,7 +100,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with empty password should return 401 Unauthorized")]
 	public void Example06_BasicAuth_WithEmptyPassword_ShouldReturn401()
 	{
 		// Arrange
@@ -120,9 +108,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var emptyPassword = "";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, emptyPassword)
 			.Get()
 		.When()
@@ -131,7 +117,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with case-sensitive username should return 401 Unauthorized")]
 	public void Example07_BasicAuth_CaseSensitiveUsername_ShouldReturn401()
 	{
 		// Arrange - Username is case-sensitive
@@ -139,9 +125,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var password = "secret123";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, password)
 			.Get()
 		.When()
@@ -150,7 +134,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with case-sensitive password should return 401 Unauthorized")]
 	public void Example08_BasicAuth_CaseSensitivePassword_ShouldReturn401()
 	{
 		// Arrange - Password is case-sensitive
@@ -158,9 +142,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var password = "Secret123"; // Wrong case
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, password)
 			.Get()
 		.When()
@@ -169,7 +151,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication with valid credentials should return complete response structure")]
 	public void Example09_BasicAuth_ValidCredentials_CheckResponseStructure()
 	{
 		// Arrange
@@ -177,9 +159,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var password = "secret123";
 
 		// Act & Assert - Validate complete response structure
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, password)
 			.Get()
 		.When()
@@ -192,7 +172,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<object>("$.message", value => value != null, "message field should exist");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Basic Authentication should maintain authentication across multiple requests")]
 	public void Example10_BasicAuth_MultipleRequests_ShouldMaintainAuthentication()
 	{
 		// Arrange
@@ -200,9 +180,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 		var password = "secret123";
 
 		// Act & Assert - First request
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, password)
 			.Get()
 		.When()
@@ -212,9 +190,7 @@ public class BasicAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "First request should be authenticated");
 
 		// Act & Assert - Second request with same credentials
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/basic")
+		Given().ApiResource("/api/auth/basic")
 			.WithBasicAuth(username, password)
 			.Get()
 		.When()

--- a/src/XUnitAssured.Http.Samples.Test/BearerAuthTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/BearerAuthTests.cs
@@ -1,34 +1,29 @@
 using XUnitAssured.Extensions.Http;
 using XUnitAssured.Http.Extensions;
-
-using static XUnitAssured.Core.DSL.ScenarioDsl;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Authentication", "Bearer")]
 /// <summary>
 /// Sample tests demonstrating Bearer Token Authentication using XUnitAssured.Http.
 /// Bearer tokens are sent in the Authorization header as "Bearer {token}".
 /// Commonly used for JWT (JSON Web Tokens) and OAuth2 access tokens.
 /// </summary>
-public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
+public class BearerAuthTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public BearerAuthTests(HttpSamplesFixture fixture)
+	public BearerAuthTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication with valid token should return success")]
 	public void Example01_BearerAuth_WithValidToken_ShouldReturnSuccess()
 	{
 		// Arrange
 		var validToken = "my-super-secret-token-12345";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(validToken)
 			.Get()
 		.When()
@@ -40,16 +35,14 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.message", value => value?.Contains("successful") == true, "Should return success message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication with invalid token should return 401 Unauthorized")]
 	public void Example02_BearerAuth_WithInvalidToken_ShouldReturn401()
 	{
 		// Arrange
 		var invalidToken = "invalid-token-xyz";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(invalidToken)
 			.Get()
 		.When()
@@ -59,13 +52,11 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication without token should return 401 Unauthorized")]
 	public void Example03_BearerAuth_WithoutToken_ShouldReturn401()
 	{
 		// Act & Assert - No authentication provided
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.Get()
 		.When()
 			.Execute()
@@ -74,16 +65,14 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication with empty token should return 401 Unauthorized")]
 	public void Example04_BearerAuth_WithEmptyToken_ShouldReturn401()
 	{
 		// Arrange
 		var emptyToken = "";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(emptyToken)
 			.Get()
 		.When()
@@ -92,7 +81,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication with custom prefix should work correctly")]
 	public void Example05_BearerAuth_WithCustomPrefix_ShouldWork()
 	{
 		// Arrange
@@ -100,9 +89,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 		var customPrefix = "Bearer"; // Default prefix
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(validToken, customPrefix)
 			.Get()
 		.When()
@@ -112,16 +99,14 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "Should be authenticated with custom prefix");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token is case-sensitive and wrong case should return 401 Unauthorized")]
 	public void Example06_BearerAuth_TokenIsCaseSensitive_ShouldReturn401()
 	{
 		// Arrange - Token is case-sensitive
 		var wrongCaseToken = "MY-SUPER-SECRET-TOKEN-12345"; // Wrong case
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(wrongCaseToken)
 			.Get()
 		.When()
@@ -131,7 +116,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 		// Note: Server returns 401 without JSON body
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token with whitespace should be trimmed and authentication succeeds")]
 	public void Example07_BearerAuth_WithWhitespaceInToken_ShouldReturn401()
 	{
 		// Arrange - Token with extra whitespace
@@ -140,9 +125,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 		var tokenWithWhitespace = "my-super-secret-token-12345 ";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(tokenWithWhitespace)
 			.Get()
 		.When()
@@ -152,16 +135,14 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "Server trims token, so authentication succeeds");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication with valid token should return complete response structure")]
 	public void Example08_BearerAuth_ValidToken_CheckResponseStructure()
 	{
 		// Arrange
 		var validToken = "my-super-secret-token-12345";
 
 		// Act & Assert - Validate complete response structure
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(validToken)
 			.Get()
 		.When()
@@ -173,16 +154,14 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<object>("$.message", value => value != null, "message field should exist");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication should maintain authentication across multiple requests")]
 	public void Example09_BearerAuth_MultipleRequests_ShouldMaintainAuthentication()
 	{
 		// Arrange
 		var validToken = "my-super-secret-token-12345";
 
 		// Act & Assert - First request
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(validToken)
 			.Get()
 		.When()
@@ -192,9 +171,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "First request should be authenticated");
 
 		// Act & Assert - Second request with same token
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(validToken)
 			.Get()
 		.When()
@@ -204,7 +181,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "Second request should be authenticated");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Bearer Token Authentication with different tokens should behave differently")]
 	public void Example10_BearerAuth_DifferentTokens_ShouldBehaveDifferently()
 	{
 		// Arrange
@@ -212,9 +189,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 		var invalidToken = "different-invalid-token";
 
 		// Act & Assert - Valid token
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(validToken)
 			.Get()
 		.When()
@@ -224,9 +199,7 @@ public class BearerAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "Valid token should authenticate");
 
 		// Act & Assert - Invalid token
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource("/api/auth/bearer")
+		Given().ApiResource("/api/auth/bearer")
 			.WithBearerToken(invalidToken)
 			.Get()
 		.When()

--- a/src/XUnitAssured.Http.Samples.Test/CertificateAuthTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/CertificateAuthTests.cs
@@ -1,10 +1,10 @@
 using XUnitAssured.Extensions.Http;
 using XUnitAssured.Http.Extensions;
-
-using static XUnitAssured.Core.DSL.ScenarioDsl;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Authentication", "Certificate")]
 /// <summary>
 /// Sample tests demonstrating Certificate Authentication (mTLS) using XUnitAssured.Http.
 /// Certificate authentication is used for mutual TLS where both client and server verify each other's identity.
@@ -12,16 +12,13 @@ namespace XUnitAssured.Http.Samples.Test;
 /// NOTE: These tests demonstrate the API usage but may require actual certificate setup to run successfully.
 /// For demonstration purposes, some tests are marked as Skip with instructions.
 /// </summary>
-public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
+public class CertificateAuthTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public CertificateAuthTests(HttpSamplesFixture fixture)
+	public CertificateAuthTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact(Skip = "Requires actual certificate setup. This test demonstrates API usage.")]
+	[Fact(Skip = "Requires actual certificate setup. This test demonstrates API usage.", DisplayName = "Certificate Authentication from file should authenticate successfully")]
 	public void Example01_Certificate_FromFile_ShouldAuthenticate()
 	{
 		// Arrange
@@ -30,7 +27,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.ApiResource($"{_fixture.BaseUrl}/api/auth/certificate")
+			.ApiResource($"{Fixture.BaseUrl}/api/auth/certificate")
 			.WithCertificate(certificatePath, certificatePassword)
 			.Get()
 		.When()
@@ -42,7 +39,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.customData.Subject", value => !string.IsNullOrEmpty(value), "Should return certificate subject");
 	}
 
-	[Fact(Skip = "Requires actual certificate in Windows Certificate Store.")]
+	[Fact(Skip = "Requires actual certificate in Windows Certificate Store.", DisplayName = "Certificate Authentication from Windows Store should authenticate successfully")]
 	public void Example02_Certificate_FromStore_ShouldAuthenticate()
 	{
 		// Arrange
@@ -52,7 +49,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.ApiResource($"{_fixture.BaseUrl}/api/auth/certificate")
+			.ApiResource($"{Fixture.BaseUrl}/api/auth/certificate")
 			.WithCertificateFromStore(thumbprint, storeLocation, storeName)
 			.Get()
 		.When()
@@ -62,7 +59,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "Should be authenticated with certificate from store");
 	}
 
-	[Fact(Skip = "Requires actual certificate instance.")]
+	[Fact(Skip = "Requires actual certificate instance.", DisplayName = "Certificate Authentication from instance should authenticate successfully")]
 	public void Example03_Certificate_FromInstance_ShouldAuthenticate()
 	{
 		// Arrange
@@ -73,7 +70,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.ApiResource($"{_fixture.BaseUrl}/api/auth/certificate")
+			.ApiResource($"{Fixture.BaseUrl}/api/auth/certificate")
 			.WithCertificateInstance(certificate)
 			.Get()
 		.When()
@@ -83,13 +80,11 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "Should be authenticated with certificate instance");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Certificate Authentication without certificate should return 401 Unauthorized")]
 	public void Example04_Certificate_WithoutCertificate_ShouldReturn401()
 	{
 		// Act & Assert - No certificate provided (using fixture's client to ensure proper test server communication)
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/certificate")
+		Given().ApiResource($"/api/auth/certificate")
 			.Get()
 		.When()
 			.Execute()
@@ -98,7 +93,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.message", value => value?.Contains("certificate") == true, "Should indicate certificate is required");
 	}
 
-	[Fact(Skip = "Requires actual certificate setup to test validation.")]
+	[Fact(Skip = "Requires actual certificate setup to test validation.", DisplayName = "Certificate Authentication should return complete response structure")]
 	public void Example05_Certificate_ValidateResponseStructure()
 	{
 		// Arrange
@@ -107,7 +102,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert - Validate certificate authentication response structure
 		Given()
-			.ApiResource($"{_fixture.BaseUrl}/api/auth/certificate")
+			.ApiResource($"{Fixture.BaseUrl}/api/auth/certificate")
 			.WithCertificate(certificatePath, certificatePassword)
 			.Get()
 		.When()
@@ -124,7 +119,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<object>("$.customData.ValidTo", value => value != null, "Certificate ValidTo should exist");
 	}
 
-	[Fact(Skip = "Requires httpsettings.json configuration and actual certificate.")]
+	[Fact(Skip = "Requires httpsettings.json configuration and actual certificate.", DisplayName = "Certificate Authentication from configuration should authenticate successfully")]
 	public void Example06_Certificate_FromConfiguration_ShouldAuthenticate()
 	{
 		// This example demonstrates using certificate configuration from httpsettings.json
@@ -140,7 +135,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.ApiResource($"{_fixture.BaseUrl}/api/auth/certificate")
+			.ApiResource($"{Fixture.BaseUrl}/api/auth/certificate")
 			.WithCertificate() // Loads from httpsettings.json
 			.Get()
 		.When()
@@ -154,7 +149,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 	/// Documentation test - demonstrates how to set up certificate authentication.
 	/// This is not a runnable test but serves as inline documentation.
 	/// </summary>
-	[Fact(Skip = "Documentation example - not a runnable test.")]
+	[Fact(Skip = "Documentation example - not a runnable test.", DisplayName = "Certificate Authentication setup guide and documentation")]
 	public void Example07_Certificate_Documentation_SetupGuide()
 	{
 		/*
@@ -230,7 +225,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 		Assert.True(true, "This is a documentation test");
 	}
 
-	[Fact(Skip = "Requires expired certificate for testing.")]
+	[Fact(Skip = "Requires expired certificate for testing.", DisplayName = "Certificate Authentication with expired certificate should handle gracefully")]
 	public void Example08_Certificate_WithExpiredCertificate_ShouldHandleGracefully()
 	{
 		// Arrange
@@ -239,7 +234,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert - Depending on configuration, this might return 401 or specific error
 		Given()
-			.ApiResource($"{_fixture.BaseUrl}/api/auth/certificate")
+			.ApiResource($"{Fixture.BaseUrl}/api/auth/certificate")
 			.WithCertificate(expiredCertPath, password)
 			.Get()
 		.When()
@@ -248,7 +243,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401); // Or specific error code for expired certificate
 	}
 
-	[Fact(Skip = "Requires untrusted certificate for testing.")]
+	[Fact(Skip = "Requires untrusted certificate for testing.", DisplayName = "Certificate Authentication with untrusted certificate should return 401 Unauthorized")]
 	public void Example09_Certificate_WithUntrustedCertificate_ShouldReturn401()
 	{
 		// Arrange
@@ -257,7 +252,7 @@ public class CertificateAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.ApiResource($"{_fixture.BaseUrl}/api/auth/certificate")
+			.ApiResource($"{Fixture.BaseUrl}/api/auth/certificate")
 			.WithCertificate(untrustedCertPath, password)
 			.Get()
 		.When()

--- a/src/XUnitAssured.Http.Samples.Test/CrudOperationsTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/CrudOperationsTests.cs
@@ -1,29 +1,26 @@
 using XUnitAssured.Extensions.Http;
 using XUnitAssured.Http.Extensions;
-
-using static XUnitAssured.Core.DSL.ScenarioDsl;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Category", "CRUD Operations")]
 /// <summary>
 /// Sample tests demonstrating CRUD operations (GET, POST, PUT, DELETE) using XUnitAssured.Http.
 /// These tests showcase the fluent DSL for testing REST API endpoints.
+/// Inherits from HttpTestBase to provide clean Given() syntax without passing fixture explicitly.
 /// </summary>
-public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
+public class CrudOperationsTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public CrudOperationsTests(HttpSamplesFixture fixture)
+	public CrudOperationsTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GET all products should return list of products with 200 OK status")]
 	public void Example01_GetAllProducts_ShouldReturnListOfProducts()
 	{
 		// Arrange & Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/products")
 			.Get()
 			.When()
@@ -33,7 +30,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(200);
 		// Note: Cannot validate array in root with current JsonPath implementation
 	}
-	[Fact]
+	[Fact(DisplayName = "GET product by ID should return product details with 200 OK status")]
 	public void Example02_GetProductById_ShouldReturnProduct()
 	{
 		// Arrange
@@ -41,7 +38,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{productId}")
 			.Get()
 			.When()
@@ -53,7 +49,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertJsonPath<decimal>("$.price", value => value > 0, "Product price should be positive");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GET product by non-existent ID should return 404 Not Found")]
 	public void Example03_GetProductById_NotFound_ShouldReturn404()
 	{
 		// Arrange
@@ -61,7 +57,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{nonExistentId}")
 			.Get()
 			.When()
@@ -71,7 +66,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertJsonPath<string>("$.message", value => value?.Contains("not found") == true, "Should return 'not found' message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "POST create product with valid data should return 201 Created with product details")]
 	public void Example04_CreateProduct_ShouldReturnCreatedProduct()
 	{
 		// Arrange
@@ -84,7 +79,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/products")
 			.Post(newProduct)
 			.When()
@@ -98,7 +92,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertJsonPath<string>("$.createdAt", value => !string.IsNullOrEmpty(value), "Created product should have createdAt timestamp");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "POST create product with invalid data should return 400 Bad Request")]
 	public void Example05_CreateProduct_WithInvalidData_ShouldReturn400()
 	{
 		// Arrange - Product with empty name (invalid)
@@ -111,17 +105,16 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/products")
 			.Post(invalidProduct)
 		.When()
-				.Execute()
+			.Execute()
 			.Then()
 				.AssertStatusCode(400)
 				.AssertJsonPath<string>("$.message", value => value?.Contains("required") == true, "Should return validation error message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "POST create product with negative price should return 400 Bad Request")]
 	public void Example06_CreateProduct_WithNegativePrice_ShouldReturn400()
 	{
 		// Arrange - Product with negative price (invalid)
@@ -134,17 +127,16 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/products")
 			.Post(invalidProduct)
 		.When()
-				.Execute()
+			.Execute()
 			.Then()
 				.AssertStatusCode(400)
 				.AssertJsonPath<string>("$.message", value => value?.Contains("non-negative") == true, "Should return price validation error");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "PUT update product should return 200 OK with updated product details")]
 	public void Example07_UpdateProduct_ShouldReturnUpdatedProduct()
 	{
 		// Arrange
@@ -158,11 +150,10 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{productId}")
 			.Put(updatedProduct)
-			.When()
-				.Execute()
+		.When()
+			.Execute()
 			.Then()
 				.AssertStatusCode(200)
 				.AssertJsonPath<int>("$.id", value => value == productId, $"Product ID should remain {productId}")
@@ -172,7 +163,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertJsonPath<string>("$.updatedAt", value => !string.IsNullOrEmpty(value), "Updated product should have updatedAt timestamp");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "PUT update non-existent product should return 404 Not Found")]
 	public void Example08_UpdateProduct_NotFound_ShouldReturn404()
 	{
 		// Arrange
@@ -186,7 +177,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{nonExistentId}")
 			.Put(updatedProduct)
 			.When()
@@ -196,7 +186,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertJsonPath<string>("$.message", value => value?.Contains("not found") == true, "Should return 'not found' message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "PUT update product with invalid data should return 400 Bad Request")]
 	public void Example09_UpdateProduct_WithInvalidData_ShouldReturn400()
 	{
 		// Arrange
@@ -210,7 +200,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{productId}")
 			.Put(invalidProduct)
 			.When()
@@ -220,7 +209,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertJsonPath<string>("$.message", value => value?.Contains("required") == true, "Should return validation error");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "DELETE product should return 204 No Content and product should not be found")]
 	public void Example10_DeleteProduct_ShouldReturn204()
 	{
 		// Arrange - First create a product to delete
@@ -232,7 +221,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 		};
 
 		var createResponse = Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/products")
 			.Post(productToDelete)
 			.When()
@@ -245,9 +233,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 		var createdProductId = createResponse.JsonPath<int>("$.id");
 
 		// Act & Assert - Delete the product
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/{createdProductId}")
+		Given().ApiResource($"/api/products/{createdProductId}")
 			.Delete()
 		.When()
 			.Execute()
@@ -256,7 +242,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Verify product was deleted
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{createdProductId}")
 			.Get()
 			.When()
@@ -265,16 +250,14 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertStatusCode(404);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "DELETE non-existent product should return 404 Not Found")]
 	public void Example11_DeleteProduct_NotFound_ShouldReturn404()
 	{
 		// Arrange
 		var nonExistentId = 9999;
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/{nonExistentId}")
+		Given().ApiResource($"/api/products/{nonExistentId}")
 			.Delete()
 		.When()
 			.Execute()
@@ -283,7 +266,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.message", value => value?.Contains("not found") == true, "Should return 'not found' message");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Complete CRUD workflow should create, read, update, and delete product successfully")]
 	public void Example12_CompleteWorkflow_CreateReadUpdateDelete()
 	{
 		// Step 1: Create a new product
@@ -295,7 +278,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 		};
 
 		var createResult = Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/products")
 			.Post(newProduct)
 		.When()
@@ -308,7 +290,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Step 2: Read the created product
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{productId}")
 			.Get()
 		.When()
@@ -326,7 +307,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 		};
 
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{productId}")
 			.Put(updatedProduct)
 		.When()
@@ -336,9 +316,7 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertJsonPath<string>("$.name", value => value == updatedProduct.name, "Product name should be updated");
 
 		// Step 4: Delete the product
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/{productId}")
+		Given().ApiResource($"/api/products/{productId}")
 			.Delete()
 		.When()
 			.Execute()
@@ -347,7 +325,6 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 
 		// Step 5: Verify deletion
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource($"/api/products/{productId}")
 			.Get()
 		.When()
@@ -356,12 +333,11 @@ public class CrudOperationsTests : IClassFixture<HttpSamplesFixture>
 				.AssertStatusCode(404);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "POST reset products should restore initial state with 3 products")]
 	public void Example13_ResetProducts_ShouldRestoreInitialState()
 	{
 		// Act & Assert
 		Given()
-			.WithHttpClient(_fixture.CreateClient())
 			.ApiResource("/api/products/reset")
 			.Post(new { })
 			.When()

--- a/src/XUnitAssured.Http.Samples.Test/CustomHeaderAuthTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/CustomHeaderAuthTests.cs
@@ -1,24 +1,21 @@
 using XUnitAssured.Extensions.Http;
 using XUnitAssured.Http.Extensions;
-
-using static XUnitAssured.Core.DSL.ScenarioDsl;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Authentication", "CustomHeader")]
 /// <summary>
 /// Sample tests demonstrating Custom Header Authentication using XUnitAssured.Http.
 /// Custom headers allow for flexible authentication schemes beyond standard patterns.
 /// </summary>
-public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
+public class CustomHeaderAuthTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public CustomHeaderAuthTests(HttpSamplesFixture fixture)
+	public CustomHeaderAuthTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with valid headers should return success")]
 	public void Example01_CustomHeader_WithValidHeaders_ShouldReturnSuccess()
 	{
 		// Arrange
@@ -26,9 +23,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		var sessionId = "session-abc-xyz";
 
 		// Act & Assert - Using WithCustomHeaders for multiple headers
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(new Dictionary<string, string>
 			{
 				["X-Custom-Auth-Token"] = authToken,
@@ -45,7 +40,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<string>("$.customData.SessionId", value => value == sessionId, $"Should return session ID: {sessionId}");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with single header using WithCustomHeader should fail when two headers required")]
 	public void Example02_CustomHeader_WithSingleHeader_UsingWithCustomHeader()
 	{
 		// Arrange
@@ -53,9 +48,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 
 		// Act & Assert - Using WithCustomHeader for single header
 		// Note: This endpoint requires TWO headers, so this should fail
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeader("X-Custom-Auth-Token", authToken)
 			.Get()
 		.When()
@@ -64,7 +57,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with invalid auth token should return 401 Unauthorized")]
 	public void Example03_CustomHeader_WithInvalidAuthToken_ShouldReturn401()
 	{
 		// Arrange
@@ -72,9 +65,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		var validSessionId = "session-abc-xyz";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(new Dictionary<string, string>
 			{
 				["X-Custom-Auth-Token"] = invalidAuthToken,
@@ -87,7 +78,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with invalid session ID should return 401 Unauthorized")]
 	public void Example04_CustomHeader_WithInvalidSessionId_ShouldReturn401()
 	{
 		// Arrange
@@ -95,9 +86,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		var invalidSessionId = "invalid-session";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(new Dictionary<string, string>
 			{
 				["X-Custom-Auth-Token"] = validAuthToken,
@@ -110,16 +99,14 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with missing auth token should return 401 Unauthorized")]
 	public void Example05_CustomHeader_MissingAuthToken_ShouldReturn401()
 	{
 		// Arrange
 		var validSessionId = "session-abc-xyz";
 
 		// Act & Assert - Missing X-Custom-Auth-Token header
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithHeader("X-Custom-Session-Id", validSessionId) // Using WithHeader instead
 			.Get()
 		.When()
@@ -128,16 +115,14 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with missing session ID should return 401 Unauthorized")]
 	public void Example06_CustomHeader_MissingSessionId_ShouldReturn401()
 	{
 		// Arrange
 		var validAuthToken = "custom-token-12345";
 
 		// Act & Assert - Missing X-Custom-Session-Id header
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithHeader("X-Custom-Auth-Token", validAuthToken) // Using WithHeader instead
 			.Get()
 		.When()
@@ -146,13 +131,11 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication without any headers should return 401 Unauthorized")]
 	public void Example07_CustomHeader_WithoutAnyHeaders_ShouldReturn401()
 	{
 		// Act & Assert - No custom headers provided
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.Get()
 		.When()
 			.Execute()
@@ -160,7 +143,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with empty auth token should return 401 Unauthorized")]
 	public void Example08_CustomHeader_WithEmptyAuthToken_ShouldReturn401()
 	{
 		// Arrange
@@ -168,9 +151,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		var validSessionId = "session-abc-xyz";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(new Dictionary<string, string>
 			{
 				["X-Custom-Auth-Token"] = emptyAuthToken,
@@ -183,7 +164,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with empty session ID should return 401 Unauthorized")]
 	public void Example09_CustomHeader_WithEmptySessionId_ShouldReturn401()
 	{
 		// Arrange
@@ -191,9 +172,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		var emptySessionId = "";
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(new Dictionary<string, string>
 			{
 				["X-Custom-Auth-Token"] = validAuthToken,
@@ -206,7 +185,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication values are case-sensitive and wrong case should return 401 Unauthorized")]
 	public void Example10_CustomHeader_CaseSensitiveValues_ShouldReturn401()
 	{
 		// Arrange - Header values are case-sensitive
@@ -214,9 +193,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		var wrongCaseSessionId = "SESSION-ABC-XYZ"; // Wrong case
 
 		// Act & Assert
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(new Dictionary<string, string>
 			{
 				["X-Custom-Auth-Token"] = wrongCaseAuthToken,
@@ -229,7 +206,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(401);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication with valid headers should return complete response structure")]
 	public void Example11_CustomHeader_ValidHeaders_CheckResponseStructure()
 	{
 		// Arrange
@@ -237,9 +214,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		var sessionId = "session-abc-xyz";
 
 		// Act & Assert - Validate complete response structure
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(new Dictionary<string, string>
 			{
 				["X-Custom-Auth-Token"] = authToken,
@@ -257,7 +232,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<object>("$.customData.SessionId", value => value != null, "customData.SessionId should exist");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Custom Header Authentication should maintain authentication across multiple requests")]
 	public void Example12_CustomHeader_MultipleRequests_ShouldMaintainAuthentication()
 	{
 		// Arrange
@@ -271,9 +246,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 		};
 
 		// Act & Assert - First request
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(headers)
 			.Get()
 		.When()
@@ -283,9 +256,7 @@ public class CustomHeaderAuthTests : IClassFixture<HttpSamplesFixture>
 			.AssertJsonPath<bool>("$.authenticated", value => value, "First request should be authenticated");
 
 		// Act & Assert - Second request with same headers
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/auth/custom-header")
+		Given().ApiResource($"/api/auth/custom-header")
 			.WithCustomHeaders(headers)
 			.Get()
 		.When()

--- a/src/XUnitAssured.Http.Samples.Test/DiagnosticTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/DiagnosticTests.cs
@@ -1,24 +1,23 @@
 using Xunit;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Category", "Diagnostics")]
 /// <summary>
 /// Simple diagnostic test to verify the test server is working
 /// </summary>
-public class DiagnosticTests : IClassFixture<HttpSamplesFixture>
+public class DiagnosticTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public DiagnosticTests(HttpSamplesFixture fixture)
+	public DiagnosticTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Test server should start and respond to HTTP requests successfully")]
 	public async Task TestServerShouldStart()
 	{
 		// Arrange
-		var client = _fixture.CreateClient();
+		var client = Fixture.CreateClient();
 
 		// Act
 		var response = await client.GetAsync("/api/products");
@@ -30,7 +29,7 @@ public class DiagnosticTests : IClassFixture<HttpSamplesFixture>
 		// Log for debugging
 		System.Console.WriteLine($"Status: {response.StatusCode}");
 		System.Console.WriteLine($"Content: {content}");
-		System.Console.WriteLine($"BaseUrl: {_fixture.BaseUrl}");
+		System.Console.WriteLine($"BaseUrl: {Fixture.BaseUrl}");
 		
 		Assert.True(response.IsSuccessStatusCode, 
 			$"Expected success but got {response.StatusCode}. Content: {content}");

--- a/src/XUnitAssured.Http.Samples.Test/HttpSamplesFixture.cs
+++ b/src/XUnitAssured.Http.Samples.Test/HttpSamplesFixture.cs
@@ -5,14 +5,17 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
+using XUnitAssured.Core.Abstractions;
+
 namespace XUnitAssured.Http.Samples.Test;
 
 /// <summary>
 /// Test fixture for HTTP samples using XUnitAssured.Http.
 /// Hosts the SampleWebApi application for integration testing.
 /// Does not depend on external configuration files.
+/// Implements IHttpClientProvider to work seamlessly with Given(fixture) syntax.
 /// </summary>
-public class HttpSamplesFixture : IDisposable
+public class HttpSamplesFixture : IHttpClientProvider, IDisposable
 {
 	private readonly WebApplicationFactory<Program> _factory;
 	private bool _disposed;

--- a/src/XUnitAssured.Http.Samples.Test/HttpSamplesTestBase.cs
+++ b/src/XUnitAssured.Http.Samples.Test/HttpSamplesTestBase.cs
@@ -1,0 +1,30 @@
+using XUnitAssured.Http.Testing;
+
+namespace XUnitAssured.Http.Samples.Test;
+
+/// <summary>
+/// Base class for all sample tests using HttpSamplesFixture.
+/// Reduces boilerplate by pre-configuring the fixture type.
+/// Derived classes only need to implement IClassFixture marker interface.
+/// </summary>
+/// <example>
+/// <code>
+/// public class MyTests : HttpSamplesTestBase
+/// {
+///     public MyTests(HttpSamplesFixture fixture) : base(fixture) { }
+///     
+///     [Fact]
+///     public void Test() => Given()...
+/// }
+/// </code>
+/// </example>
+public abstract class HttpSamplesTestBase : HttpTestBase<HttpSamplesFixture>
+{
+	/// <summary>
+	/// Initializes a new instance of the HttpSamplesTestBase class.
+	/// </summary>
+	/// <param name="fixture">The HTTP samples fixture</param>
+	protected HttpSamplesTestBase(HttpSamplesFixture fixture) : base(fixture)
+	{
+	}
+}

--- a/src/XUnitAssured.Http.Samples.Test/HybridValidationTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/HybridValidationTests.cs
@@ -3,33 +3,28 @@ using SampleWebApi.Models;
 using XUnitAssured.Core.DSL;
 using XUnitAssured.Extensions.Http;
 using XUnitAssured.Http.Extensions;
-using static XUnitAssured.Core.DSL.ScenarioDsl;
-
+using XUnitAssured.Http.Testing;
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Category", "Validation")]
 /// <summary>
 /// Sample tests demonstrating the HYBRID APPROACH:
 /// 1. Field validation for structure checking (detects breaking changes)
 /// 2. AssertJsonPath with Shouldly (field-specific assertions)
 /// </summary>
-public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
+public class HybridValidationTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public HybridValidationTests(HttpSamplesFixture fixture)
+	public HybridValidationTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Validate contract should detect JSON structure automatically")]
 	public void Example01_ValidateContract_DetectsStructureAutomatically()
 	{
 		// This test validates key fields in the JSON structure
 		// Note: Full contract validation with NJsonSchema requires exact casing match
 
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/1")
+		Given().ApiResource($"/api/products/1")
 			.Get()
 		.When()
 			.Execute()
@@ -42,15 +37,13 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(200);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Corrected AssertJsonPath with Shouldly should provide clean syntax")]
 	public void Example02_CorrectedAssertJsonPath_WithShouldly()
 	{
 		// This test demonstrates the CORRECTED AssertJsonPath
 		// No more ugly type conversions! Clean Shouldly syntax!
 
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/1")
+		Given().ApiResource($"/api/products/1")
 			.Get()
 		.When()
 			.Execute()
@@ -75,16 +68,14 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(200);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Hybrid approach should validate both structure and business rules")]
 	public void Example03_HybridApproach_StructureAndBusinessRules()
 	{
 		// BEST PRACTICE: Validate structure and business rules
 		// 1. Validate key fields exist with correct types
 		// 2. Validate business rules on those fields
 
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/1")
+		Given().ApiResource($"/api/products/1")
 			.Get()
 		.When()
 			.Execute()
@@ -102,14 +93,12 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(200);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Array handling should work correctly with individual element validation")]
 	public void Example04_ArrayHandling_StillWorks()
 	{
 		// Validate array responses by checking individual elements
 
-		var result = Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products")
+		var result = Given().ApiResource($"/api/products")
 			.Get()
 		.When()
 			.Execute()
@@ -132,14 +121,12 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 		firstElement.GetProperty("name").GetString().ShouldNotBeNullOrEmpty();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Backward compatibility with legacy Func syntax should still work")]
 	public void Example05_BackwardCompatibility_LegacyFuncStillWorks()
 	{
 		// The old Func<T, bool> syntax still works for backward compatibility
 
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/1")
+		Given().ApiResource($"/api/products/1")
 			.Get()
 		.When()
 			.Execute()
@@ -151,7 +138,7 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(200);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Complete workflow should showcase all validation features")]
 	public void Example06_CompleteWorkflow_ShowcaseAllFeatures()
 	{
 		// Create a product
@@ -162,9 +149,7 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 			price = 299.99m
 		};
 
-		var createResult = Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products")
+		var createResult = Given().ApiResource($"/api/products")
 			.Post(newProduct)
 		.When()
 			.Execute()
@@ -183,9 +168,7 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 		var productId = createResult.JsonPath<int>("$.id");
 
 		// Verify with GET
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/{productId}")
+		Given().ApiResource($"/api/products/{productId}")
 			.Get()
 		.When()
 			.Execute()
@@ -198,9 +181,7 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(200);
 
 		// Cleanup
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/{productId}")
+		Given().ApiResource($"/api/products/{productId}")
 			.Delete()
 		.When()
 			.Execute()
@@ -208,7 +189,7 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 			.AssertStatusCode(204);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Detect breaking changes by validating all expected fields")]
 	public void Example07_DetectBreakingChanges_ValidateAllFields()
 	{
 		// This test will FAIL if:
@@ -216,9 +197,7 @@ public class HybridValidationTests : IClassFixture<HttpSamplesFixture>
 		// - Field types change (e.g., Price becomes string)
 		// - Field names change (e.g., "name" -> "productName")
 
-		Given()
-			.WithHttpClient(_fixture.CreateClient())
-			.ApiResource($"/api/products/1")
+		Given().ApiResource($"/api/products/1")
 			.Get()
 		.When()
 			.Execute()

--- a/src/XUnitAssured.Http.Samples.Test/SimpleIntegrationTests.cs
+++ b/src/XUnitAssured.Http.Samples.Test/SimpleIntegrationTests.cs
@@ -1,40 +1,37 @@
 using Shouldly;
 
 using XUnitAssured.Http.Extensions;
-
-using static XUnitAssured.Core.DSL.ScenarioDsl;
+using XUnitAssured.Http.Testing;
 
 namespace XUnitAssured.Http.Samples.Test;
 
+[Trait("Category", "Integration")]
 /// <summary>
 /// Diagnostic tests to debug XUnitAssured integration.
 /// Demonstrates usage of XUnitAssured.Extensions for improved test readability.
 /// </summary>
-public class SimpleIntegrationTests : IClassFixture<HttpSamplesFixture>
+public class SimpleIntegrationTests : HttpTestBase<HttpSamplesFixture>, IClassFixture<HttpSamplesFixture>
 {
-	private readonly HttpSamplesFixture _fixture;
-
-	public SimpleIntegrationTests(HttpSamplesFixture fixture)
+	public SimpleIntegrationTests(HttpSamplesFixture fixture) : base(fixture)
 	{
-		_fixture = fixture;
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Direct HTTP Client should work and return successful response")]
 	public async Task DirectHttpClient_ShouldWork()
 	{
 		// This should work - direct HttpClient call
-		var client = _fixture.CreateClient();
+		var client = Fixture.CreateClient();
 		var response = await client.GetAsync("/api/products/1");
 
 
 		response.IsSuccessStatusCode.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "XUnitAssured with custom HTTP Client should work with relative URLs")]
 	public void XUnitAssured_WithCustomHttpClient_ShouldWork()
 	{
 		// ✅ Using WithHttpClient to inject test server's client
-		var client = _fixture.CreateClient();
+		var client = Fixture.CreateClient();
 
 		var scenario = Given()
 			.WithHttpClient(client)                   // ← Inject test server's HttpClient

--- a/src/XUnitAssured.Http/Extensions/HttpScenarioExtensions.cs
+++ b/src/XUnitAssured.Http/Extensions/HttpScenarioExtensions.cs
@@ -28,6 +28,16 @@ public static class HttpScenarioExtensions
 		{
 			existingHttpClient = existingStep.CustomHttpClient;
 		}
+		
+		// Check if HttpClientProvider was set via Given(IHttpClientProvider)
+		if (existingHttpClient == null)
+		{
+			var provider = scenario.Context.GetProperty<Core.Abstractions.IHttpClientProvider>("HttpClientProvider");
+			if (provider != null)
+			{
+				existingHttpClient = provider.CreateClient();
+			}
+		}
 
 		var step = new HttpRequestStep
 		{

--- a/src/XUnitAssured.Http/Steps/HttpRequestStep.cs
+++ b/src/XUnitAssured.Http/Steps/HttpRequestStep.cs
@@ -253,6 +253,8 @@ public class HttpRequestStep : ITestStep
 					g => g.SelectMany(h => h.Value.Split(',').Select(v => v.Trim())).AsEnumerable()
 				);
 
+			// HTTP errors (4xx, 5xx) should still create an HttpStepResult with the status code
+			// but Success should be false since these are error responses
 			Result = HttpStepResult.CreateHttpSuccess(
 				statusCode: statusCode,
 				responseBody: responseBody,

--- a/src/XUnitAssured.Http/Testing/HttpTestBase.cs
+++ b/src/XUnitAssured.Http/Testing/HttpTestBase.cs
@@ -1,0 +1,78 @@
+using System;
+using XUnitAssured.Core.Abstractions;
+using XUnitAssured.Core.DSL;
+using XUnitAssured.Core.Testing;
+
+namespace XUnitAssured.Http.Testing;
+
+/// <summary>
+/// Specialized base class for HTTP integration tests using XUnitAssured.Http.
+/// Provides a clean Given() method that automatically uses the injected HTTP fixture.
+/// This class extends FixtureTestBase and adds HTTP-specific functionality.
+/// </summary>
+/// <typeparam name="TFixture">The fixture type that implements IHttpClientProvider</typeparam>
+/// <example>
+/// <code>
+/// public class MyApiTests : HttpTestBase&lt;MyTestFixture&gt;, IClassFixture&lt;MyTestFixture&gt;
+/// {
+///     public MyApiTests(MyTestFixture fixture) : base(fixture) { }
+///     
+///     [Fact]
+///     public void TestEndpoint()
+///     {
+///         // Given() automatically uses the fixture's HttpClient
+///         Given()
+///             .ApiResource("/api/endpoint")
+///             .Get()
+///             .When()
+///                 .Execute()
+///             .Then()
+///                 .AssertStatusCode(200);
+///     }
+/// }
+/// </code>
+/// </example>
+public abstract class HttpTestBase<TFixture> : FixtureTestBase<TFixture> 
+	where TFixture : IHttpClientProvider
+{
+	/// <summary>
+	/// Initializes a new instance of the HttpTestBase class.
+	/// </summary>
+	/// <param name="fixture">The test fixture that implements IHttpClientProvider</param>
+	protected HttpTestBase(TFixture fixture) : base(fixture)
+	{
+	}
+
+	/// <summary>
+	/// Starts a new test scenario with the fixture's HttpClient automatically configured.
+	/// This is a convenience method that wraps ScenarioDsl.Given(fixture).
+	/// </summary>
+	/// <returns>A new test scenario pre-configured with the fixture's HttpClient</returns>
+	/// <example>
+	/// <code>
+	/// Given()
+	///     .ApiResource("/api/products")
+	///     .Get()
+	///     .When()
+	///         .Execute()
+	///     .Then()
+	///         .AssertStatusCode(200);
+	/// </code>
+	/// </example>
+	protected new ITestScenario Given()
+	{
+		return ScenarioDsl.Given(Fixture);
+	}
+
+	/// <summary>
+	/// Starts a new test scenario with a custom context.
+	/// Use this when you need to provide a specific test context.
+	/// </summary>
+	/// <param name="context">Custom test context</param>
+	/// <returns>A new test scenario with the specified context</returns>
+	protected new ITestScenario Given(ITestContext context)
+	{
+		return ScenarioDsl.Given(context);
+	}
+}
+

--- a/src/XUnitAssured.Kafka/KafkaSettingsValidator.cs
+++ b/src/XUnitAssured.Kafka/KafkaSettingsValidator.cs
@@ -104,7 +104,8 @@ public class KafkaSettingsValidator : IValidateOptions<KafkaSettings>
 				}
 			}
 
-		// Validate authentication if provided
+			// Validate authentication if provided
+			// Only validate BasicAuthUserInfo when explicitly set to UserInfo (value 1)
 			if (options.SchemaRegistry.BasicAuthCredentialsSource == AuthCredentialsSource.UserInfo)
 			{
 				if (string.IsNullOrWhiteSpace(options.SchemaRegistry.BasicAuthUserInfo))

--- a/src/XUnitAssured.Kafka/SchemaRegistrySettings.cs
+++ b/src/XUnitAssured.Kafka/SchemaRegistrySettings.cs
@@ -31,10 +31,11 @@ public class SchemaRegistrySettings
 
 	/// <summary>
 	/// Authentication credentials source.
-	/// Use 0 for None, 1 for UserInfo, 2 for SaslInherit.
-	/// Default is 0 (None - no authentication).
+	/// Use AuthCredentialsSource.UserInfo for basic authentication.
+	/// Use AuthCredentialsSource.SaslInherit to inherit from Kafka SASL settings.
+	/// Default is SaslInherit (2 - no authentication required).
 	/// </summary>
-	public AuthCredentialsSource BasicAuthCredentialsSource { get; set; } = (AuthCredentialsSource)0;
+	public AuthCredentialsSource BasicAuthCredentialsSource { get; set; } = AuthCredentialsSource.SaslInherit;
 
 	/// <summary>
 	/// Basic authentication credentials in format "username:password".

--- a/src/XUnitAssured.Tests/ConsumeRestTest.cs
+++ b/src/XUnitAssured.Tests/ConsumeRestTest.cs
@@ -1,12 +1,13 @@
 namespace XUnitAssured.Tests;
 
+[Trait("Category", "Integration Rest + Kafka")]
 /// <summary>
 /// Integration tests demonstrating the complete XUnitAssured DSL.
 /// These tests show HTTP + Kafka integration scenarios.
 /// </summary>
 public class ConsumeRestTest
 {
-	[Fact(Skip = "Integration test - requires real API")]
+	[Fact(Skip = "Integration test - requires real API", DisplayName = "HTTP POST should work with fluent DSL syntax")]
 	public void HttpPost_Should_Work_With_Fluent_DSL()
 	{
 		// Simple HTTP test using jsonplaceholder (public API)
@@ -26,7 +27,7 @@ public class ConsumeRestTest
 			});
 	}
 
-	[Fact(Skip = "Integration test - requires real API and Kafka")]
+	[Fact(Skip = "Integration test - requires real API and Kafka", DisplayName = "Complete workflow should validate API response and Kafka topic message successfully")]
 	public void GetApiRetornaValidaTopicoECSTSucesso()
 	{
 		// Complete test: HTTP POST + Kafka message validation
@@ -65,7 +66,7 @@ public class ConsumeRestTest
 			});
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Complete DSL syntax reference and documentation for HTTP and Kafka operations")]
 	public void Complete_DSL_Syntax_Documentation()
 	{
 		// ============================================

--- a/src/XUnitAssured.Tests/CoreTests/StepStorageTests.cs
+++ b/src/XUnitAssured.Tests/CoreTests/StepStorageTests.cs
@@ -6,13 +6,15 @@ using XUnitAssured.Core.Storage;
 
 namespace XUnitAssured.Tests.CoreTests;
 
+[Trait("Category", "Core")]
+[Trait("Component", "Storage")]
 /// <summary>
 /// Unit tests for StepStorage class.
 /// Validates step storage and retrieval functionality.
 /// </summary>
 public class StepStorageTests
 {
-	[Fact]
+	[Fact(DisplayName = "Step storage should store and retrieve step by name successfully")]
 	public void StepStorage_Should_Store_And_Retrieve_Step()
 	{
 		// Arrange
@@ -28,7 +30,7 @@ public class StepStorageTests
 		retrieved.Name.ShouldBe("TestStep");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Indexer should throw KeyNotFoundException when step is not found")]
 	public void Indexer_Should_Throw_When_Step_Not_Found()
 	{
 		// Arrange
@@ -38,7 +40,7 @@ public class StepStorageTests
 		Should.Throw<KeyNotFoundException>(() => storage["NonExistent"]);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Indexer should throw ArgumentException when step name is null")]
 	public void Indexer_Should_Throw_When_Name_Is_Null()
 	{
 		// Arrange
@@ -48,7 +50,7 @@ public class StepStorageTests
 		Should.Throw<ArgumentException>(() => storage[null!]);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Indexer should throw ArgumentException when step name is whitespace")]
 	public void Indexer_Should_Throw_When_Name_Is_Whitespace()
 	{
 		// Arrange
@@ -58,7 +60,7 @@ public class StepStorageTests
 		Should.Throw<ArgumentException>(() => storage["   "]);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Save should replace existing step with same name")]
 	public void Save_Should_Replace_Existing_Step()
 	{
 		// Arrange
@@ -76,7 +78,7 @@ public class StepStorageTests
 		retrieved.Name.ShouldBe("Step2");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Save should throw ArgumentException when step name is null")]
 	public void Save_Should_Throw_When_Name_Is_Null()
 	{
 		// Arrange
@@ -87,7 +89,7 @@ public class StepStorageTests
 		Should.Throw<ArgumentException>(() => storage.Save(null!, step));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Save should throw ArgumentNullException when step is null")]
 	public void Save_Should_Throw_When_Step_Is_Null()
 	{
 		// Arrange
@@ -97,7 +99,7 @@ public class StepStorageTests
 		Should.Throw<ArgumentNullException>(() => storage.Save("Test", null!));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "TryGet should return step when it exists in storage")]
 	public void TryGet_Should_Return_Step_When_Exists()
 	{
 		// Arrange
@@ -113,7 +115,7 @@ public class StepStorageTests
 		retrieved.ShouldBe(step);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "TryGet should return null when step is not found")]
 	public void TryGet_Should_Return_Null_When_Not_Found()
 	{
 		// Arrange
@@ -126,7 +128,7 @@ public class StepStorageTests
 		retrieved.ShouldBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "TryGet should return null when step name is null")]
 	public void TryGet_Should_Return_Null_When_Name_Is_Null()
 	{
 		// Arrange
@@ -139,7 +141,7 @@ public class StepStorageTests
 		retrieved.ShouldBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Contains should return true when step exists in storage")]
 	public void Contains_Should_Return_True_When_Step_Exists()
 	{
 		// Arrange
@@ -151,7 +153,7 @@ public class StepStorageTests
 		storage.Contains("First").ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Contains should return false when step is not found")]
 	public void Contains_Should_Return_False_When_Step_Not_Found()
 	{
 		// Arrange
@@ -161,7 +163,7 @@ public class StepStorageTests
 		storage.Contains("NonExistent").ShouldBeFalse();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Contains should be case-insensitive when checking step names")]
 	public void Contains_Should_Be_Case_Insensitive()
 	{
 		// Arrange
@@ -175,7 +177,7 @@ public class StepStorageTests
 		storage.Contains("FiRsT").ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GetStepNames should return all stored step names")]
 	public void GetStepNames_Should_Return_All_Stored_Names()
 	{
 		// Arrange
@@ -194,7 +196,7 @@ public class StepStorageTests
 		names.ShouldContain("Third");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GetStepNames should return empty collection when no steps are stored")]
 	public void GetStepNames_Should_Return_Empty_When_No_Steps()
 	{
 		// Arrange
@@ -207,7 +209,7 @@ public class StepStorageTests
 		names.ShouldBeEmpty();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Clear should remove all steps from storage")]
 	public void Clear_Should_Remove_All_Steps()
 	{
 		// Arrange

--- a/src/XUnitAssured.Tests/CoreTests/TestScenarioTests.cs
+++ b/src/XUnitAssured.Tests/CoreTests/TestScenarioTests.cs
@@ -8,12 +8,14 @@ using static XUnitAssured.Core.DSL.ScenarioDsl;
 
 namespace XUnitAssured.Tests.CoreTests;
 
+[Trait("Category", "Core")]
+[Trait("Component", "Scenario")]
 /// <summary>
 /// Unit tests for TestScenario and DSL infrastructure.
 /// </summary>
 public class TestScenarioTests
 {
-	[Fact]
+	[Fact(DisplayName = "Given should create a new test scenario with context")]
 	public void Given_Should_Create_New_Scenario()
 	{
 		// Act
@@ -25,7 +27,7 @@ public class TestScenarioTests
 		scenario.Context.Steps.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Given should create scenario with empty steps collection")]
 	public void Given_Should_Create_Scenario_With_Empty_Steps()
 	{
 		// Act
@@ -35,7 +37,7 @@ public class TestScenarioTests
 		scenario.Context.Steps.GetStepNames().ShouldBeEmpty();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "SetCurrentStep should set the current step in scenario")]
 	public void SetCurrentStep_Should_Set_Step()
 	{
 		// Arrange
@@ -49,7 +51,7 @@ public class TestScenarioTests
 		scenario.CurrentStep.ShouldBe(mockStep);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "And should return the same scenario instance for chaining")]
 	public void And_Should_Return_Same_Scenario()
 	{
 		// Arrange
@@ -63,7 +65,7 @@ public class TestScenarioTests
 		result.ShouldBe(scenario);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "On should return the same scenario instance for chaining")]
 	public void On_Should_Return_Same_Scenario()
 	{
 		// Arrange
@@ -77,7 +79,7 @@ public class TestScenarioTests
 		result.ShouldBe(scenario);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "ExecuteCurrentStepAsync should execute the current step")]
 	public async Task ExecuteCurrentStepAsync_Should_Execute_Step()
 	{
 		// Arrange
@@ -92,7 +94,7 @@ public class TestScenarioTests
 		mockStep.IsExecuted.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "ExecuteCurrentStepAsync should not execute the same step twice")]
 	public async Task ExecuteCurrentStepAsync_Should_Not_Execute_Twice()
 	{
 		// Arrange
@@ -110,7 +112,7 @@ public class TestScenarioTests
 		mockStep.ExecutionCount.ShouldBe(1); // Still 1, not 2
 	}
 
-	[Fact]
+	[Fact(DisplayName = "TestContext should store and retrieve properties correctly")]
 	public void TestContext_Should_Store_And_Retrieve_Properties()
 	{
 		// Arrange
@@ -126,7 +128,7 @@ public class TestScenarioTests
 		context.GetProperty<int>("key2").ShouldBe(123);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "TestContext should return default value for missing property")]
 	public void TestContext_Should_Return_Default_For_Missing_Property()
 	{
 		// Arrange

--- a/src/XUnitAssured.Tests/CoreTests/TestStepResultTests.cs
+++ b/src/XUnitAssured.Tests/CoreTests/TestStepResultTests.cs
@@ -4,13 +4,15 @@ using XUnitAssured.Core.Results;
 
 namespace XUnitAssured.Tests.CoreTests;
 
+[Trait("Category", "Core")]
+[Trait("Component", "Result")]
 /// <summary>
 /// Unit tests for TestStepResult class.
 /// Validates the core result functionality independent of technology.
 /// </summary>
 public class TestStepResultTests
 {
-	[Fact]
+	[Fact(DisplayName = "TestStepResult should store success status and data correctly")]
 	public void TestStepResult_Should_Store_Success_And_Data()
 	{
 		// Arrange
@@ -31,7 +33,7 @@ public class TestStepResultTests
 		result.DataType!.Name.ShouldContain("AnonymousType");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "TestStepResult should store custom properties correctly")]
 	public void TestStepResult_Should_Store_Properties()
 	{
 		// Arrange & Act
@@ -52,7 +54,7 @@ public class TestStepResultTests
 		result.GetProperty<bool>("BoolProp").ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GetProperty should return default value for missing key")]
 	public void GetProperty_Should_Return_Default_For_Missing_Key()
 	{
 		// Arrange
@@ -68,7 +70,7 @@ public class TestStepResultTests
 		result.GetProperty<bool>("NonExistent").ShouldBe(false);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GetData should convert data to compatible types")]
 	public void GetData_Should_Convert_Compatible_Types()
 	{
 		// Arrange
@@ -84,7 +86,7 @@ public class TestStepResultTests
 		result.GetData<object>().ShouldBe("test string");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateSuccess should create a successful result with data and properties")]
 	public void CreateSuccess_Should_Create_Successful_Result()
 	{
 		// Arrange
@@ -105,7 +107,7 @@ public class TestStepResultTests
 		result.Errors.ShouldBeEmpty();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateFailure should create a failed result with error messages")]
 	public void CreateFailure_Should_Create_Failed_Result_With_Errors()
 	{
 		// Arrange
@@ -122,7 +124,7 @@ public class TestStepResultTests
 		result.Errors.ShouldContain("Error 2");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateFailure from exception should capture exception message")]
 	public void CreateFailure_From_Exception_Should_Capture_Message()
 	{
 		// Arrange
@@ -138,7 +140,7 @@ public class TestStepResultTests
 		result.Errors[0].ShouldBe("Something went wrong");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Metadata should calculate duration between start and completion time")]
 	public void Metadata_Should_Calculate_Duration()
 	{
 		// Arrange
@@ -161,7 +163,7 @@ public class TestStepResultTests
 		result.Metadata.Duration.TotalSeconds.ShouldBeLessThanOrEqualTo(2.1);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Metadata should support tags for categorization")]
 	public void Metadata_Should_Support_Tags()
 	{
 		// Arrange & Act
@@ -180,7 +182,7 @@ public class TestStepResultTests
 		result.Metadata.Tags.ShouldContain("http");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Metadata WithStatus should create new instance with updated status")]
 	public void Metadata_WithStatus_Should_Create_New_Instance()
 	{
 		// Arrange
@@ -200,7 +202,7 @@ public class TestStepResultTests
 		original.Status.ShouldBe(StepStatus.Running); // Original unchanged
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Metadata WithIncrementedAttempt should increment attempt count")]
 	public void Metadata_WithIncrementedAttempt_Should_Increment_Count()
 	{
 		// Arrange

--- a/src/XUnitAssured.Tests/HttpTests/ApiKeyAuthTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/ApiKeyAuthTests.cs
@@ -3,12 +3,14 @@ using XUnitAssured.Http.Extensions;
 
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Authentication", "ApiKey")]
 /// <summary>
 /// Tests for API Key authentication.
 /// </summary>
 public class ApiKeyAuthTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should add API key in HTTP header successfully")]
 	public void Should_Add_ApiKey_In_Header()
 	{
 		// Arrange & Act
@@ -22,7 +24,7 @@ public class ApiKeyAuthTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should add API key in query parameter successfully")]
 	public void Should_Add_ApiKey_In_Query()
 	{
 		// Arrange & Act
@@ -35,7 +37,7 @@ public class ApiKeyAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support custom API key name")]
 	public void Should_Support_Custom_Key_Name()
 	{
 		// Arrange & Act
@@ -48,7 +50,7 @@ public class ApiKeyAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support API key configuration via auth config")]
 	public void Should_Support_ApiKey_Via_Config()
 	{
 		// Arrange & Act
@@ -64,7 +66,7 @@ public class ApiKeyAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "ApiKeyAuthConfig should have default values")]
 	public void ApiKeyAuthConfig_Should_Have_Defaults()
 	{
 		// Arrange & Act
@@ -75,7 +77,7 @@ public class ApiKeyAuthTests
 		config.Location.ShouldBe(ApiKeyLocation.Header);
 	}
 
-	[Fact(Skip = "Integration test - requires real API with API key")]
+	[Fact(Skip = "Integration test - requires real API with API key", DisplayName = "Integration test should authenticate with API key successfully")]
 	public void Integration_Should_Authenticate_With_ApiKey()
 	{
 		var apiKey = Environment.GetEnvironmentVariable("TEST_API_KEY");

--- a/src/XUnitAssured.Tests/HttpTests/AuthenticationTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/AuthenticationTests.cs
@@ -3,12 +3,14 @@ using XUnitAssured.Http.Extensions;
 
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Component", "Authentication")]
 /// <summary>
 /// Tests for HTTP authentication functionality.
 /// </summary>
 public class AuthenticationTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should add Basic Authentication header successfully")]
 	public void Should_Add_Basic_Auth_Header()
 	{
 		// Arrange & Act
@@ -22,7 +24,7 @@ public class AuthenticationTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should add Bearer token header successfully")]
 	public void Should_Add_Bearer_Token_Header()
 	{
 		// Arrange & Act
@@ -36,7 +38,7 @@ public class AuthenticationTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support custom token prefix for Bearer authentication")]
 	public void Should_Support_Custom_Token_Prefix()
 	{
 		// Arrange & Act
@@ -49,7 +51,7 @@ public class AuthenticationTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support authentication configuration via action")]
 	public void Should_Support_Auth_Config_Action()
 	{
 		// Arrange & Act
@@ -65,7 +67,7 @@ public class AuthenticationTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should allow no authentication override")]
 	public void Should_Allow_No_Auth_Override()
 	{
 		// Arrange & Act
@@ -78,7 +80,7 @@ public class AuthenticationTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw InvalidOperationException when not HTTP step")]
 	public void Should_Throw_When_Not_Http_Step()
 	{
 		// Arrange
@@ -89,7 +91,7 @@ public class AuthenticationTests
 			scenario.WithBasicAuth("user", "pass"));
 	}
 
-	[Fact(Skip = "Integration test - requires real API with basic auth")]
+	[Fact(Skip = "Integration test - requires real API with basic auth", DisplayName = "Integration test should authenticate with Basic Authentication successfully")]
 	public void Integration_Should_Authenticate_With_Basic_Auth()
 	{
 		// This test requires a real API endpoint with basic authentication
@@ -104,7 +106,7 @@ public class AuthenticationTests
 			});
 	}
 
-	[Fact(Skip = "Integration test - requires API with bearer token")]
+	[Fact(Skip = "Integration test - requires API with bearer token", DisplayName = "Integration test should authenticate with Bearer token successfully")]
 	public void Integration_Should_Authenticate_With_Bearer_Token()
 	{
 		// This test requires a real API endpoint that accepts bearer tokens

--- a/src/XUnitAssured.Tests/HttpTests/CertificateAuthTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/CertificateAuthTests.cs
@@ -5,6 +5,8 @@ using XUnitAssured.Http.Extensions;
 
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Authentication", "Certificate")]
 /// <summary>
 /// Tests for Certificate (mTLS) authentication.
 /// Note: Most tests are skipped as they require valid X509 certificates.
@@ -12,7 +14,7 @@ namespace XUnitAssured.Tests.HttpTests;
 /// </summary>
 public class CertificateAuthTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should configure certificate authentication from file")]
 	public void Should_Configure_Certificate_From_File()
 	{
 		// Arrange & Act
@@ -26,7 +28,7 @@ public class CertificateAuthTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure certificate authentication from Windows certificate store")]
 	public void Should_Configure_Certificate_From_Store()
 	{
 		// Arrange & Act
@@ -39,7 +41,7 @@ public class CertificateAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support certificate authentication via auth config")]
 	public void Should_Support_Certificate_Via_Config()
 	{
 		// Arrange & Act
@@ -55,7 +57,7 @@ public class CertificateAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CertificateAuthConfig should have default values")]
 	public void CertificateAuthConfig_Should_Have_Defaults()
 	{
 		// Arrange & Act
@@ -66,7 +68,7 @@ public class CertificateAuthTests
 		config.StoreName.ShouldBe(StoreName.My);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw ArgumentNullException when certificate instance is null")]
 	public void Should_Throw_When_Certificate_Is_Null()
 	{
 		// Arrange
@@ -77,7 +79,7 @@ public class CertificateAuthTests
 			scenario.WithCertificateInstance(null!));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw InvalidOperationException when not HTTP step")]
 	public void Should_Throw_When_Not_Http_Step()
 	{
 		// Arrange
@@ -88,7 +90,7 @@ public class CertificateAuthTests
 			scenario.WithCertificate("path/to/cert.pfx"));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "FlurlClientFactory should clear cache successfully")]
 	public void FlurlClientFactory_Should_Clear_Cache_Successfully()
 	{
 		// Act
@@ -98,7 +100,7 @@ public class CertificateAuthTests
 		FlurlClientFactory.CachedClientCount.ShouldBe(0);
 	}
 
-	[Fact(Skip = "Integration test - requires real certificate and mTLS server")]
+	[Fact(Skip = "Integration test - requires real certificate and mTLS server", DisplayName = "Integration test should authenticate with client certificate successfully")]
 	public void Integration_Should_Authenticate_With_Certificate()
 	{
 		var certPath = Environment.GetEnvironmentVariable("TEST_CLIENT_CERT_PATH");

--- a/src/XUnitAssured.Tests/HttpTests/CustomHeaderAuthTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/CustomHeaderAuthTests.cs
@@ -1,11 +1,13 @@
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Authentication", "CustomHeader")]
 /// <summary>
 /// Tests for Custom Header authentication.
 /// </summary>
 public class CustomHeaderAuthTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should add single custom header successfully")]
 	public void Should_Add_Single_Custom_Header()
 	{
 		// Arrange & Act
@@ -19,7 +21,7 @@ public class CustomHeaderAuthTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should add multiple custom headers successfully")]
 	public void Should_Add_Multiple_Custom_Headers()
 	{
 		// Arrange
@@ -40,7 +42,7 @@ public class CustomHeaderAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support custom header via auth config")]
 	public void Should_Support_CustomHeader_Via_Config()
 	{
 		// Arrange & Act
@@ -56,7 +58,7 @@ public class CustomHeaderAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CustomHeaderAuthConfig should add headers correctly")]
 	public void CustomHeaderAuthConfig_Should_Add_Headers()
 	{
 		// Arrange
@@ -72,7 +74,7 @@ public class CustomHeaderAuthTests
 		config.Headers["X-Another"].ShouldBe("value2");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw ArgumentException when no headers are provided")]
 	public void Should_Throw_When_No_Headers_Provided()
 	{
 		// Arrange
@@ -83,7 +85,7 @@ public class CustomHeaderAuthTests
 			scenario.WithCustomHeaders(new System.Collections.Generic.Dictionary<string, string>()));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw InvalidOperationException when not HTTP step")]
 	public void Should_Throw_When_Not_Http_Step()
 	{
 		// Arrange
@@ -94,7 +96,7 @@ public class CustomHeaderAuthTests
 			scenario.WithCustomHeader("X-Auth", "value"));
 	}
 
-	[Fact(Skip = "Integration test - requires real API")]
+	[Fact(Skip = "Integration test - requires real API", DisplayName = "Integration test should authenticate with custom header successfully")]
 	public void Integration_Should_Authenticate_With_Custom_Header()
 	{
 		var authToken = System.Environment.GetEnvironmentVariable("TEST_AUTH_TOKEN");

--- a/src/XUnitAssured.Tests/HttpTests/Examples/CertificateFromSettingsExamples.cs
+++ b/src/XUnitAssured.Tests/HttpTests/Examples/CertificateFromSettingsExamples.cs
@@ -4,6 +4,8 @@ using XUnitAssured.Http.Extensions;
 
 namespace XUnitAssured.Tests.HttpTests.Examples;
 
+[Trait("Category", "Examples")]
+[Trait("Authentication", "Certificate")]
 /// <summary>
 /// Examples demonstrating the .WithCertificate() extension method
 /// that automatically loads certificate configuration from httpsettings.json
@@ -31,7 +33,7 @@ public class CertificateFromSettingsExamples
 	/// CLIENT_CERT_PATH=C:\Certs\client-cert.pfx
 	/// CLIENT_CERT_PASSWORD=MySecurePassword123
 	/// </summary>
-	[Fact(Skip = "Example - requires certificate in httpsettings.json")]
+	[Fact(Skip = "Example - requires certificate in httpsettings.json", DisplayName = "Example: Using WithCertificate without parameters loads from httpsettings.json")]
 	public void Example_WithCertificate_From_Settings()
 	{
 		Given()
@@ -65,7 +67,7 @@ public class CertificateFromSettingsExamples
 	/// 
 	/// Load environment: HttpSettings.Load(environment: "mtls")
 	/// </summary>
-	[Fact(Skip = "Example - requires mtls environment in httpsettings.json")]
+	[Fact(Skip = "Example - requires mtls environment in httpsettings.json", DisplayName = "Example: Using environment-specific certificate configuration")]
 	public void Example_WithCertificate_From_Environment()
 	{
 		// Load mtls environment settings
@@ -96,7 +98,7 @@ public class CertificateFromSettingsExamples
 	///   }
 	/// }
 	/// </summary>
-	[Fact(Skip = "Example - requires certificate in store")]
+	[Fact(Skip = "Example - requires certificate in store", DisplayName = "Example: Using certificate from Windows Certificate Store via settings")]
 	public void Example_WithCertificate_From_Store_Via_Settings()
 	{
 		Given()
@@ -109,7 +111,7 @@ public class CertificateFromSettingsExamples
 	/// Example 4: Override settings with explicit certificate
 	/// Useful when you need different certificate for specific test
 	/// </summary>
-	[Fact(Skip = "Example - requires certificates")]
+	[Fact(Skip = "Example - requires certificates", DisplayName = "Example: Override settings certificate with explicit certificate for specific test")]
 	public void Example_Override_Settings_Certificate()
 	{
 		// Most tests use settings certificate
@@ -129,7 +131,7 @@ public class CertificateFromSettingsExamples
 	/// Example 5: Multiple requests with same certificate (cached)
 	/// The certificate and FlurlClient are cached automatically by thumbprint
 	/// </summary>
-	[Fact(Skip = "Example - demonstrates caching")]
+	[Fact(Skip = "Example - demonstrates caching", DisplayName = "Example: Multiple requests with same certificate use cached FlurlClient for performance")]
 	public void Example_Certificate_Caching_Performance()
 	{
 		// First request: loads certificate and creates FlurlClient (~50ms)
@@ -154,7 +156,7 @@ public class CertificateFromSettingsExamples
 	/// <summary>
 	/// Example 6: Error handling when certificate not configured
 	/// </summary>
-	[Fact]
+	[Fact(DisplayName = "Example: Error handling when certificate is not configured in settings")]
 	public void Example_Error_When_Certificate_Not_In_Settings()
 	{
 		// If httpsettings.json doesn't have certificate config,
@@ -170,7 +172,7 @@ public class CertificateFromSettingsExamples
 	/// Example 7: Complete real-world scenario
 	/// Production-ready pattern with error handling
 	/// </summary>
-	[Fact(Skip = "Example - production pattern")]
+	[Fact(Skip = "Example - production pattern", DisplayName = "Example: Complete real-world scenario with production-ready error handling")]
 	public void Example_Production_Pattern()
 	{
 		try

--- a/src/XUnitAssured.Tests/HttpTests/HttpRequestStepTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/HttpRequestStepTests.cs
@@ -7,13 +7,15 @@ using XUnitAssured.Http.Steps;
 
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Component", "RequestStep")]
 /// <summary>
 /// Integration tests for HttpRequestStep.
 /// Uses real HTTP requests to public APIs for testing.
 /// </summary>
 public class HttpRequestStepTests
 {
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should execute GET request successfully")]
 	public async Task HttpRequestStep_Should_Execute_Get_Request()
 	{
 		// Arrange
@@ -39,7 +41,7 @@ public class HttpRequestStepTests
 		httpResult.ResponseBody.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should execute POST request successfully")]
 	public async Task HttpRequestStep_Should_Execute_Post_Request()
 	{
 		// Arrange
@@ -65,7 +67,7 @@ public class HttpRequestStepTests
 		httpResult.IsSuccessStatusCode.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should handle 404 Not Found error correctly")]
 	public async Task HttpRequestStep_Should_Handle_404_Error()
 	{
 		// Arrange
@@ -89,7 +91,7 @@ public class HttpRequestStepTests
 		httpResult.IsClientError.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should add custom headers to request")]
 	public async Task HttpRequestStep_Should_Add_Custom_Headers()
 	{
 		// Arrange
@@ -116,7 +118,7 @@ public class HttpRequestStepTests
 		httpResult.StatusCode.ShouldBe(200);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should add query parameters to request")]
 	public async Task HttpRequestStep_Should_Add_Query_Parameters()
 	{
 		// Arrange
@@ -144,7 +146,7 @@ public class HttpRequestStepTests
 		httpResult.ResponseBody.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should set IsExecuted flag after execution")]
 	public async Task HttpRequestStep_Should_Set_IsExecuted_After_Execution()
 	{
 		// Arrange
@@ -165,7 +167,7 @@ public class HttpRequestStepTests
 		step.Result.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should validate result successfully")]
 	public async Task HttpRequestStep_Should_Validate_Successfully()
 	{
 		// Arrange
@@ -190,7 +192,7 @@ public class HttpRequestStepTests
 		step.IsValid.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should throw InvalidOperationException when validating before execution")]
 	public async Task HttpRequestStep_Should_Throw_When_Validating_Before_Execution()
 	{
 		// Arrange
@@ -204,7 +206,7 @@ public class HttpRequestStepTests
 		Should.Throw<InvalidOperationException>(() => step.Validate(result => { }));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should have correct StepType value")]
 	public void HttpRequestStep_Should_Have_Correct_StepType()
 	{
 		// Arrange & Act
@@ -217,7 +219,7 @@ public class HttpRequestStepTests
 		step.StepType.ShouldBe("Http");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpRequestStep should handle timeout errors correctly", Skip = "Timeout behavior is unreliable with external public APIs")]
 	public async Task HttpRequestStep_Should_Handle_Timeout()
 	{
 		// Arrange

--- a/src/XUnitAssured.Tests/HttpTests/HttpSettingsTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/HttpSettingsTests.cs
@@ -2,12 +2,14 @@ using XUnitAssured.Http.Configuration;
 
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Component", "Configuration")]
 /// <summary>
 /// Tests for HttpSettings and HttpSettingsLoader.
 /// </summary>
 public class HttpSettingsTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should create HttpSettings with default values")]
 	public void Should_Create_Default_Settings()
 	{
 		// Act
@@ -20,7 +22,7 @@ public class HttpSettingsTests
 		settings.Authentication.Type.ShouldBe(AuthenticationType.None);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should merge HttpSettings correctly")]
 	public void Should_Merge_Settings()
 	{
 		// Arrange
@@ -53,7 +55,7 @@ public class HttpSettingsTests
 		merged.DefaultHeaders.Count.ShouldBe(2); // Merged
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should load HttpSettings from configuration file")]
 	public void Should_Load_Settings_From_File()
 	{
 		// Act
@@ -64,7 +66,7 @@ public class HttpSettingsTests
 		// Will use default settings if httpsettings.json doesn't exist
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should clear HttpSettings cache successfully")]
 	public void Should_Clear_Settings_Cache()
 	{
 		// Arrange
@@ -78,7 +80,7 @@ public class HttpSettingsTests
 		settings.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support Basic Authentication configuration")]
 	public void Should_Support_Basic_Auth_Config()
 	{
 		// Arrange
@@ -94,7 +96,7 @@ public class HttpSettingsTests
 		config.Basic.Password.ShouldBe("testpass");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support Bearer token configuration")]
 	public void Should_Support_Bearer_Token_Config()
 	{
 		// Arrange

--- a/src/XUnitAssured.Tests/HttpTests/HttpStepResultTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/HttpStepResultTests.cs
@@ -6,13 +6,15 @@ using XUnitAssured.Http.Results;
 
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Component", "Result")]
 /// <summary>
 /// Unit tests for HttpStepResult class.
 /// Validates HTTP-specific result functionality and helpers.
 /// </summary>
 public class HttpStepResultTests
 {
-	[Fact]
+	[Fact(DisplayName = "HttpStepResult should expose status code correctly")]
 	public void HttpStepResult_Should_Expose_StatusCode()
 	{
 		// Arrange & Act
@@ -31,7 +33,7 @@ public class HttpStepResultTests
 		result.StatusCodeEnum.ShouldBe(HttpStatusCode.OK);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpStepResult should expose response body correctly")]
 	public void HttpStepResult_Should_Expose_ResponseBody()
 	{
 		// Arrange
@@ -50,10 +52,14 @@ public class HttpStepResultTests
 
 		// Assert
 		result.ResponseBody.ShouldBe(responseData);
-		result.GetResponseBody<dynamic>().ShouldBe(responseData);
+		result.ResponseBody.ShouldNotBeNull();
+		
+		// Verify GetResponseBody returns the same object reference
+		var dynamicResponse = result.GetResponseBody<object>();
+		dynamicResponse.ShouldBe(responseData);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpStepResult should expose response headers correctly")]
 	public void HttpStepResult_Should_Expose_Headers()
 	{
 		// Arrange
@@ -81,7 +87,7 @@ public class HttpStepResultTests
 		result.Headers["X-Custom-Header"].ShouldContain("custom-value");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "HttpStepResult should expose ContentType and ReasonPhrase correctly")]
 	public void HttpStepResult_Should_Expose_ContentType_And_ReasonPhrase()
 	{
 		// Arrange & Act
@@ -101,7 +107,7 @@ public class HttpStepResultTests
 		result.ReasonPhrase.ShouldBe("OK");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "IsSuccessStatusCode should return true for 2xx status codes")]
 	public void IsSuccessStatusCode_Should_Return_True_For_2xx()
 	{
 		// Arrange & Act
@@ -115,7 +121,7 @@ public class HttpStepResultTests
 		result204.IsSuccessStatusCode.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "IsSuccessStatusCode should return false for non-2xx status codes")]
 	public void IsSuccessStatusCode_Should_Return_False_For_Non_2xx()
 	{
 		// Arrange & Act
@@ -127,7 +133,7 @@ public class HttpStepResultTests
 		result500.IsSuccessStatusCode.ShouldBeFalse();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "IsRedirect should return true for 3xx status codes")]
 	public void IsRedirect_Should_Return_True_For_3xx()
 	{
 		// Arrange & Act
@@ -141,7 +147,7 @@ public class HttpStepResultTests
 		result304.IsRedirect.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "IsClientError should return true for 4xx status codes")]
 	public void IsClientError_Should_Return_True_For_4xx()
 	{
 		// Arrange & Act
@@ -155,7 +161,7 @@ public class HttpStepResultTests
 		result403.IsClientError.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "IsServerError should return true for 5xx status codes")]
 	public void IsServerError_Should_Return_True_For_5xx()
 	{
 		// Arrange & Act
@@ -169,7 +175,7 @@ public class HttpStepResultTests
 		result503.IsServerError.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateHttpSuccess should create complete HTTP result with all properties")]
 	public void CreateHttpSuccess_Should_Create_Complete_Result()
 	{
 		// Arrange
@@ -198,7 +204,7 @@ public class HttpStepResultTests
 		result.Metadata.Status.ShouldBe(StepStatus.Succeeded);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateHttpSuccess should set Success to false for non-2xx status codes")]
 	public void CreateHttpSuccess_Should_Set_Success_False_For_Non_2xx()
 	{
 		// Act
@@ -213,7 +219,7 @@ public class HttpStepResultTests
 		result.IsClientError.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateFailure should create failed result with exception message")]
 	public void CreateFailure_Should_Create_Failed_Result()
 	{
 		// Arrange

--- a/src/XUnitAssured.Tests/HttpTests/OAuth2AuthTests.cs
+++ b/src/XUnitAssured.Tests/HttpTests/OAuth2AuthTests.cs
@@ -1,11 +1,13 @@
 namespace XUnitAssured.Tests.HttpTests;
 
+[Trait("Category", "Http")]
+[Trait("Authentication", "OAuth2")]
 /// <summary>
 /// Tests for OAuth 2.0 authentication.
 /// </summary>
 public class OAuth2AuthTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should configure OAuth2 with client credentials grant type")]
 	public void Should_Configure_OAuth2_Client_Credentials()
 	{
 		// Arrange & Act
@@ -19,7 +21,7 @@ public class OAuth2AuthTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure OAuth2 with scopes successfully")]
 	public void Should_Configure_OAuth2_With_Scopes()
 	{
 		// Arrange & Act
@@ -32,7 +34,7 @@ public class OAuth2AuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure OAuth2 with password grant type")]
 	public void Should_Configure_OAuth2_Password_Grant()
 	{
 		// Arrange & Act
@@ -53,7 +55,7 @@ public class OAuth2AuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should support OAuth2 configuration via auth config")]
 	public void Should_Support_OAuth2_Via_AuthConfig()
 	{
 		// Arrange & Act
@@ -69,7 +71,7 @@ public class OAuth2AuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "OAuth2Config should have default values")]
 	public void OAuth2Config_Should_Have_Defaults()
 	{
 		// Arrange & Act
@@ -79,7 +81,7 @@ public class OAuth2AuthTests
 		config.GrantType.ShouldBe(Http.Configuration.OAuth2GrantType.ClientCredentials);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw InvalidOperationException when not HTTP step")]
 	public void Should_Throw_When_Not_Http_Step()
 	{
 		// Arrange
@@ -90,7 +92,7 @@ public class OAuth2AuthTests
 			scenario.WithOAuth2("url", "id", "secret"));
 	}
 
-	[Fact(Skip = "Integration test - requires real OAuth2 server")]
+	[Fact(Skip = "Integration test - requires real OAuth2 server", DisplayName = "Integration test should authenticate with OAuth2 successfully")]
 	public void Integration_Should_Authenticate_With_OAuth2()
 	{
 		var tokenUrl = System.Environment.GetEnvironmentVariable("OAUTH_TOKEN_URL");

--- a/src/XUnitAssured.Tests/KafkaSettingsTests.cs
+++ b/src/XUnitAssured.Tests/KafkaSettingsTests.cs
@@ -1,12 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-
 using Confluent.Kafka;
-
-using Microsoft.Extensions.Options;
-
-using Xunit;
 
 using XUnitAssured.Kafka;
 

--- a/src/XUnitAssured.Tests/KafkaTests/KafkaConsumeStepTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/KafkaConsumeStepTests.cs
@@ -3,6 +3,8 @@ using XUnitAssured.Kafka.Steps;
 
 namespace XUnitAssured.Tests.KafkaTests;
 
+[Trait("Category", "Kafka")]
+[Trait("Component", "ConsumeStep")]
 /// <summary>
 /// Unit tests for KafkaConsumeStep and Kafka DSL.
 /// Note: These are unit tests for the step structure, not integration tests.
@@ -10,7 +12,7 @@ namespace XUnitAssured.Tests.KafkaTests;
 /// </summary>
 public class KafkaConsumeStepTests
 {
-	[Fact]
+	[Fact(DisplayName = "KafkaConsumeStep should have correct StepType value")]
 	public void KafkaConsumeStep_Should_Have_Correct_StepType()
 	{
 		// Arrange & Act
@@ -23,7 +25,7 @@ public class KafkaConsumeStepTests
 		step.StepType.ShouldBe("Kafka");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaConsumeStep should store topic name correctly")]
 	public void KafkaConsumeStep_Should_Store_Topic()
 	{
 		// Arrange & Act
@@ -36,7 +38,7 @@ public class KafkaConsumeStepTests
 		step.Topic.ShouldBe("my-topic");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaConsumeStep should store schema type correctly")]
 	public void KafkaConsumeStep_Should_Store_SchemaType()
 	{
 		// Arrange & Act
@@ -50,7 +52,7 @@ public class KafkaConsumeStepTests
 		step.SchemaType.ShouldBe(typeof(string));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaConsumeStep should have default timeout of 30 seconds")]
 	public void KafkaConsumeStep_Should_Have_Default_Timeout()
 	{
 		// Arrange & Act
@@ -63,7 +65,7 @@ public class KafkaConsumeStepTests
 		step.Timeout.ShouldBe(TimeSpan.FromSeconds(30));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaConsumeStep should allow custom timeout configuration")]
 	public void KafkaConsumeStep_Should_Allow_Custom_Timeout()
 	{
 		// Arrange & Act
@@ -77,7 +79,7 @@ public class KafkaConsumeStepTests
 		step.Timeout.ShouldBe(TimeSpan.FromSeconds(60));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaConsumeStep should have default bootstrap servers")]
 	public void KafkaConsumeStep_Should_Have_Default_BootstrapServers()
 	{
 		// Arrange & Act
@@ -90,7 +92,7 @@ public class KafkaConsumeStepTests
 		step.BootstrapServers.ShouldBe("localhost:9092");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaConsumeStep should have default consumer group ID")]
 	public void KafkaConsumeStep_Should_Have_Default_GroupId()
 	{
 		// Arrange & Act
@@ -103,7 +105,7 @@ public class KafkaConsumeStepTests
 		step.GroupId.ShouldBe("xunitassured-consumer");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Topic extension should create KafkaConsumeStep")]
 	public void Topic_Extension_Should_Create_KafkaStep()
 	{
 		// Arrange
@@ -118,7 +120,7 @@ public class KafkaConsumeStepTests
 		((KafkaConsumeStep)scenario.CurrentStep).Topic.ShouldBe("my-topic");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Topic extension should throw ArgumentException when topic is null")]
 	public void Topic_Extension_Should_Throw_When_Topic_Is_Null()
 	{
 		// Arrange
@@ -128,7 +130,7 @@ public class KafkaConsumeStepTests
 		Should.Throw<ArgumentException>(() => scenario.Topic(null!));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Topic extension should throw ArgumentException when topic is empty")]
 	public void Topic_Extension_Should_Throw_When_Topic_Is_Empty()
 	{
 		// Arrange
@@ -138,7 +140,7 @@ public class KafkaConsumeStepTests
 		Should.Throw<ArgumentException>(() => scenario.Topic("   "));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "WithSchema should update schema type in KafkaConsumeStep")]
 	public void WithSchema_Should_Update_SchemaType()
 	{
 		// Arrange
@@ -152,7 +154,7 @@ public class KafkaConsumeStepTests
 		kafkaStep.SchemaType.ShouldBe(typeof(string));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "WithTimeout should update timeout in KafkaConsumeStep")]
 	public void WithTimeout_Should_Update_Timeout()
 	{
 		// Arrange
@@ -166,7 +168,7 @@ public class KafkaConsumeStepTests
 		kafkaStep.Timeout.ShouldBe(TimeSpan.FromSeconds(60));
 	}
 
-	[Fact]
+	[Fact(DisplayName = "WithBootstrapServers should update bootstrap servers in KafkaConsumeStep")]
 	public void WithBootstrapServers_Should_Update_BootstrapServers()
 	{
 		// Arrange
@@ -180,7 +182,7 @@ public class KafkaConsumeStepTests
 		kafkaStep.BootstrapServers.ShouldBe("kafka:9092");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "WithGroupId should update consumer group ID in KafkaConsumeStep")]
 	public void WithGroupId_Should_Update_GroupId()
 	{
 		// Arrange
@@ -194,7 +196,7 @@ public class KafkaConsumeStepTests
 		kafkaStep.GroupId.ShouldBe("my-consumer-group");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Kafka DSL should chain fluently with all configuration methods")]
 	public void Kafka_DSL_Should_Chain_Fluently()
 	{
 		// Act

--- a/src/XUnitAssured.Tests/KafkaTests/KafkaStepResultTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/KafkaStepResultTests.cs
@@ -6,13 +6,15 @@ using XUnitAssured.Kafka.Results;
 
 namespace XUnitAssured.Tests.KafkaTests;
 
+[Trait("Category", "Kafka")]
+[Trait("Component", "Result")]
 /// <summary>
 /// Unit tests for KafkaStepResult class.
 /// Validates Kafka-specific result functionality and helpers.
 /// </summary>
 public class KafkaStepResultTests
 {
-	[Fact]
+	[Fact(DisplayName = "KafkaStepResult should expose message data correctly")]
 	public void KafkaStepResult_Should_Expose_Message()
 	{
 		// Arrange
@@ -31,10 +33,14 @@ public class KafkaStepResultTests
 
 		// Assert
 		result.Message.ShouldBe(message);
-		result.GetMessage<dynamic>().ShouldBe(message);
+		result.Message.ShouldNotBeNull();
+		
+		// Verify GetMessage returns the same object reference
+		var messageObject = result.GetMessage<object>();
+		messageObject.ShouldBe(message);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaStepResult should expose Kafka metadata correctly")]
 	public void KafkaStepResult_Should_Expose_Kafka_Metadata()
 	{
 		// Arrange
@@ -62,7 +68,7 @@ public class KafkaStepResultTests
 		result.Key.ShouldBe("message-key");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaStepResult should handle null partition and offset gracefully")]
 	public void KafkaStepResult_Should_Handle_Null_Partition_And_Offset()
 	{
 		// Act
@@ -80,7 +86,7 @@ public class KafkaStepResultTests
 		result.Offset.ShouldBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateKafkaConsumeSuccess should create complete result with all properties")]
 	public void CreateKafkaConsumeSuccess_Should_Create_Complete_Result()
 	{
 		// Arrange
@@ -116,7 +122,7 @@ public class KafkaStepResultTests
 		result.Metadata.Status.ShouldBe(StepStatus.Succeeded);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateKafkaProduceSuccess should create complete result with all properties")]
 	public void CreateKafkaProduceSuccess_Should_Create_Complete_Result()
 	{
 		// Arrange
@@ -150,7 +156,7 @@ public class KafkaStepResultTests
 		result.GetProperty<string>("Status").ShouldBe("Persisted");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateKafkaProduceSuccess should set Success to false for NotPersisted status")]
 	public void CreateKafkaProduceSuccess_Should_Set_Success_False_For_NotPersisted()
 	{
 		// Arrange
@@ -174,7 +180,7 @@ public class KafkaStepResultTests
 		result.Success.ShouldBeFalse();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateFailure should create failed result with exception message")]
 	public void CreateFailure_Should_Create_Failed_Result()
 	{
 		// Arrange
@@ -192,7 +198,7 @@ public class KafkaStepResultTests
 		result.Errors[0].ShouldContain("Timed out");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "CreateTimeout should create timeout result with error message")]
 	public void CreateTimeout_Should_Create_Timeout_Result()
 	{
 		// Act
@@ -207,7 +213,7 @@ public class KafkaStepResultTests
 		result.Errors[0].ShouldContain("30");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GetHeaderValue should return header value as bytes")]
 	public void GetHeaderValue_Should_Return_Header_Bytes()
 	{
 		// Arrange
@@ -232,7 +238,7 @@ public class KafkaStepResultTests
 		System.Text.Encoding.UTF8.GetString(retrievedValue!).ShouldBe("correlation-123");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GetHeaderValue should return null for missing header")]
 	public void GetHeaderValue_Should_Return_Null_For_Missing_Header()
 	{
 		// Arrange
@@ -253,7 +259,7 @@ public class KafkaStepResultTests
 		retrievedValue.ShouldBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "GetHeaderValue should return null when headers collection is missing")]
 	public void GetHeaderValue_Should_Return_Null_When_Headers_Missing()
 	{
 		// Arrange

--- a/src/XUnitAssured.Tests/KafkaTests/SaslPlainAuthTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/SaslPlainAuthTests.cs
@@ -5,12 +5,14 @@ using Shouldly;
 
 namespace XUnitAssured.Tests.KafkaTests;
 
+[Trait("Category", "Kafka")]
+[Trait("Authentication", "SASL-PLAIN")]
 /// <summary>
 /// Tests for SASL/PLAIN authentication in Kafka.
 /// </summary>
 public class SaslPlainAuthTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should configure SASL/PLAIN authentication with explicit credentials")]
 	public void Should_Configure_SaslPlain_With_Explicit_Credentials()
 	{
 		// Arrange & Act
@@ -24,7 +26,7 @@ public class SaslPlainAuthTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure SASL/PLAIN authentication without SSL")]
 	public void Should_Configure_SaslPlain_Without_Ssl()
 	{
 		// Arrange & Act
@@ -37,7 +39,7 @@ public class SaslPlainAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure SASL/PLAIN authentication via Kafka auth config")]
 	public void Should_Configure_SaslPlain_Via_Config()
 	{
 		// Arrange & Act
@@ -53,7 +55,7 @@ public class SaslPlainAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should disable Kafka authentication when requested")]
 	public void Should_Disable_Authentication()
 	{
 		// Arrange & Act
@@ -66,7 +68,7 @@ public class SaslPlainAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "SaslPlainConfig should default to use SSL")]
 	public void SaslPlainConfig_Should_Default_To_UseSsl()
 	{
 		// Arrange & Act
@@ -80,7 +82,7 @@ public class SaslPlainAuthTests
 		config.UseSsl.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaAuthConfig UseSaslPlain should set correct authentication type")]
 	public void KafkaAuthConfig_UseSaslPlain_Should_Set_Correct_Type()
 	{
 		// Arrange
@@ -96,7 +98,7 @@ public class SaslPlainAuthTests
 		config.SaslPlain.Password.ShouldBe("pass");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw InvalidOperationException when not Kafka step")]
 	public void Should_Throw_When_Not_Kafka_Step()
 	{
 		// Arrange
@@ -107,7 +109,7 @@ public class SaslPlainAuthTests
 			scenario.WithSaslPlain("user", "pass"));
 	}
 
-	[Fact(Skip = "Integration test - requires Kafka broker with SASL/PLAIN")]
+	[Fact(Skip = "Integration test - requires Kafka broker with SASL/PLAIN", DisplayName = "Integration test should connect to Kafka with SASL/PLAIN authentication")]
 	public void Integration_Should_Connect_With_SaslPlain()
 	{
 		var username = Environment.GetEnvironmentVariable("KAFKA_USERNAME");

--- a/src/XUnitAssured.Tests/KafkaTests/SaslScramAuthTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/SaslScramAuthTests.cs
@@ -6,12 +6,14 @@ using Shouldly;
 
 namespace XUnitAssured.Tests.KafkaTests;
 
+[Trait("Category", "Kafka")]
+[Trait("Authentication", "SASL-SCRAM")]
 /// <summary>
 /// Tests for SASL/SCRAM authentication in Kafka.
 /// </summary>
 public class SaslScramAuthTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should configure SASL/SCRAM-SHA-256 authentication with explicit credentials")]
 	public void Should_Configure_SaslScram256_With_Explicit_Credentials()
 	{
 		// Arrange & Act
@@ -25,7 +27,7 @@ public class SaslScramAuthTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure SASL/SCRAM-SHA-512 authentication with explicit credentials")]
 	public void Should_Configure_SaslScram512_With_Explicit_Credentials()
 	{
 		// Arrange & Act
@@ -38,7 +40,7 @@ public class SaslScramAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure SASL/SCRAM authentication without SSL")]
 	public void Should_Configure_SaslScram_Without_Ssl()
 	{
 		// Arrange & Act
@@ -51,7 +53,7 @@ public class SaslScramAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure SASL/SCRAM authentication via Kafka auth config")]
 	public void Should_Configure_SaslScram_Via_Config()
 	{
 		// Arrange & Act
@@ -67,7 +69,7 @@ public class SaslScramAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "SaslScramConfig should default to SCRAM-SHA-256 mechanism")]
 	public void SaslScramConfig_Should_Default_To_ScramSha256()
 	{
 		// Arrange & Act
@@ -82,7 +84,7 @@ public class SaslScramAuthTests
 		config.UseSsl.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaAuthConfig UseSaslScram256 should set correct authentication type")]
 	public void KafkaAuthConfig_UseSaslScram256_Should_Set_Correct_Type()
 	{
 		// Arrange
@@ -99,7 +101,7 @@ public class SaslScramAuthTests
 		config.SaslScram.Mechanism.ShouldBe(SaslMechanism.ScramSha256);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaAuthConfig UseSaslScram512 should set correct authentication type")]
 	public void KafkaAuthConfig_UseSaslScram512_Should_Set_Correct_Type()
 	{
 		// Arrange
@@ -114,7 +116,7 @@ public class SaslScramAuthTests
 		config.SaslScram!.Mechanism.ShouldBe(SaslMechanism.ScramSha512);
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw InvalidOperationException when not Kafka step")]
 	public void Should_Throw_When_Not_Kafka_Step()
 	{
 		// Arrange
@@ -125,7 +127,7 @@ public class SaslScramAuthTests
 			scenario.WithSaslScram256("user", "pass"));
 	}
 
-	[Fact(Skip = "Integration test - requires Kafka broker with SASL/SCRAM-SHA-256")]
+	[Fact(Skip = "Integration test - requires Kafka broker with SASL/SCRAM-SHA-256", DisplayName = "Integration test should connect to Kafka with SASL/SCRAM-SHA-256 authentication")]
 	public void Integration_Should_Connect_With_SaslScram256()
 	{
 		var username = Environment.GetEnvironmentVariable("MSK_USERNAME");
@@ -146,7 +148,7 @@ public class SaslScramAuthTests
 		}
 	}
 
-	[Fact(Skip = "Integration test - requires Kafka broker with SASL/SCRAM-SHA-512")]
+	[Fact(Skip = "Integration test - requires Kafka broker with SASL/SCRAM-SHA-512", DisplayName = "Integration test should connect to Kafka with SASL/SCRAM-SHA-512 authentication")]
 	public void Integration_Should_Connect_With_SaslScram512()
 	{
 		var username = Environment.GetEnvironmentVariable("KAFKA_SCRAM512_USERNAME");

--- a/src/XUnitAssured.Tests/KafkaTests/SslAuthTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/SslAuthTests.cs
@@ -5,12 +5,14 @@ using Shouldly;
 
 namespace XUnitAssured.Tests.KafkaTests;
 
+[Trait("Category", "Kafka")]
+[Trait("Authentication", "SSL")]
 /// <summary>
 /// Tests for SSL/TLS authentication in Kafka.
 /// </summary>
 public class SslAuthTests
 {
-	[Fact]
+	[Fact(DisplayName = "Should configure SSL authentication with CA certificate location")]
 	public void Should_Configure_Ssl_With_CaLocation()
 	{
 		// Arrange & Act
@@ -24,7 +26,7 @@ public class SslAuthTests
 		scenario.CurrentStep.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure SSL authentication without certificate verification")]
 	public void Should_Configure_Ssl_Without_CertificateVerification()
 	{
 		// Arrange & Act
@@ -37,7 +39,7 @@ public class SslAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure Mutual TLS authentication with client certificate and key")]
 	public void Should_Configure_MutualTls()
 	{
 		// Arrange & Act
@@ -53,7 +55,7 @@ public class SslAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure Mutual TLS authentication with CA certificate and key password")]
 	public void Should_Configure_MutualTls_With_CaAndPassword()
 	{
 		// Arrange & Act
@@ -71,7 +73,7 @@ public class SslAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should configure SSL authentication via Kafka auth config")]
 	public void Should_Configure_Ssl_Via_Config()
 	{
 		// Arrange & Act
@@ -87,7 +89,7 @@ public class SslAuthTests
 		scenario.ShouldNotBeNull();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "SslConfig should default to enable certificate verification")]
 	public void SslConfig_Should_Default_To_EnableVerification()
 	{
 		// Arrange & Act
@@ -97,7 +99,7 @@ public class SslAuthTests
 		config.EnableSslCertificateVerification.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaAuthConfig UseSsl should set correct authentication type")]
 	public void KafkaAuthConfig_UseSsl_Should_Set_Correct_Type()
 	{
 		// Arrange
@@ -113,7 +115,7 @@ public class SslAuthTests
 		config.Ssl.EnableSslCertificateVerification.ShouldBeTrue();
 	}
 
-	[Fact]
+	[Fact(DisplayName = "KafkaAuthConfig UseMutualTls should set correct authentication type")]
 	public void KafkaAuthConfig_UseMutualTls_Should_Set_Correct_Type()
 	{
 		// Arrange
@@ -132,7 +134,7 @@ public class SslAuthTests
 		config.Ssl.SslKeyLocation.ShouldBe("/key.pem");
 	}
 
-	[Fact]
+	[Fact(DisplayName = "Should throw InvalidOperationException when not Kafka step")]
 	public void Should_Throw_When_Not_Kafka_Step()
 	{
 		// Arrange
@@ -143,7 +145,7 @@ public class SslAuthTests
 			scenario.WithSsl("/path/to/ca-cert.pem"));
 	}
 
-	[Fact(Skip = "Integration test - requires Kafka broker with SSL")]
+	[Fact(Skip = "Integration test - requires Kafka broker with SSL", DisplayName = "Integration test should connect to Kafka with SSL authentication")]
 	public void Integration_Should_Connect_With_Ssl()
 	{
 		var caLocation = Environment.GetEnvironmentVariable("KAFKA_CA_CERT_PATH");
@@ -163,7 +165,7 @@ public class SslAuthTests
 		}
 	}
 
-	[Fact(Skip = "Integration test - requires Kafka broker with mutual TLS")]
+	[Fact(Skip = "Integration test - requires Kafka broker with mutual TLS", DisplayName = "Integration test should connect to Kafka with Mutual TLS authentication")]
 	public void Integration_Should_Connect_With_MutualTls()
 	{
 		var clientCert = Environment.GetEnvironmentVariable("KAFKA_CLIENT_CERT_PATH");

--- a/src/XUnitAssured.Tests/XUnitAssured.Tests.csproj
+++ b/src/XUnitAssured.Tests/XUnitAssured.Tests.csproj
@@ -19,9 +19,13 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" Condition="'$(TargetFramework)' != 'net7.0'" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" Condition="'$(TargetFramework)' != 'net7.0'" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.9" Condition="'$(TargetFramework)' != 'net7.0'" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" Condition="'$(TargetFramework)' != 'net7.0'" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.9" Condition="'$(TargetFramework)' != 'net7.0'" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Implementa IHttpClientProvider e overload Given(fixture) para cenários mais limpos. Adiciona FixtureTestBase e HttpTestBase para reduzir boilerplate e padronizar acesso ao fixture. Refatora todos os testes para herdar das novas bases, elimina .WithHttpClient explícito, adiciona [Trait] e DisplayName nos testes. Melhora documentação, corrige valores padrão de configuração e adiciona dependências de configuração do .NET. Torna o framework mais extensível e fácil de usar para integração.