### PR TITLE
Adiciona suporte a produção Kafka no DSL fluente

### DIFF
--- a/src/XUnitAssured.Kafka/Extensions/KafkaScenarioExtensions.cs
+++ b/src/XUnitAssured.Kafka/Extensions/KafkaScenarioExtensions.cs
@@ -11,8 +11,8 @@ namespace XUnitAssured.Kafka.Extensions;
 public static class KafkaScenarioExtensions
 {
 	/// <summary>
-	/// Starts a Kafka consume step with the specified topic.
-	/// Usage: Given().Topic("my-topic").Consume()
+	/// Sets the Kafka topic for the next operation (Consume or Produce).
+	/// Usage: Given().Topic("my-topic").Consume() or Given().Topic("my-topic").Produce(value)
 	/// </summary>
 	public static ITestScenario Topic(this ITestScenario scenario, string topic)
 	{
@@ -22,12 +22,8 @@ public static class KafkaScenarioExtensions
 		if (string.IsNullOrWhiteSpace(topic))
 			throw new ArgumentException("Topic name cannot be null or whitespace.", nameof(topic));
 
-		var step = new KafkaConsumeStep
-		{
-			Topic = topic
-		};
-
-		scenario.SetCurrentStep(step);
+		// Store topic in context for Consume() or Produce() to use
+		scenario.Context.SetProperty("_KafkaTopic", topic);
 		return scenario;
 	}
 
@@ -37,10 +33,17 @@ public static class KafkaScenarioExtensions
 	/// </summary>
 	public static ITestScenario Consume(this ITestScenario scenario)
 	{
-		if (scenario.CurrentStep is not KafkaConsumeStep)
-			throw new InvalidOperationException("Current step is not a Kafka consume step. Call Topic() first.");
+		var topic = scenario.Context.GetProperty<string>("_KafkaTopic");
 
-		// Step is already configured, just return
+		if (string.IsNullOrWhiteSpace(topic))
+			throw new InvalidOperationException("No topic specified. Call Topic() first.");
+
+		var step = new KafkaConsumeStep
+		{
+			Topic = topic
+		};
+
+		scenario.SetCurrentStep(step);
 		return scenario;
 	}
 
@@ -69,25 +72,50 @@ public static class KafkaScenarioExtensions
 	}
 
 	/// <summary>
-	/// Sets the timeout for consuming a message.
+	/// Sets the timeout for consuming or producing a message.
 	/// </summary>
 	public static ITestScenario WithTimeout(this ITestScenario scenario, TimeSpan timeout)
 	{
-		if (scenario.CurrentStep is not KafkaConsumeStep currentStep)
-			throw new InvalidOperationException("Current step is not a Kafka consume step.");
-
-		// Create new step with updated timeout (immutable pattern)
-		var newStep = new KafkaConsumeStep
+		if (scenario.CurrentStep is KafkaConsumeStep consumeStep)
 		{
-			Topic = currentStep.Topic,
-			SchemaType = currentStep.SchemaType,
-			Timeout = timeout,
-			ConsumerConfig = currentStep.ConsumerConfig,
-			GroupId = currentStep.GroupId,
-			BootstrapServers = currentStep.BootstrapServers
-		};
+			// Create new step with updated timeout (immutable pattern)
+			var newStep = new KafkaConsumeStep
+			{
+				Topic = consumeStep.Topic,
+				SchemaType = consumeStep.SchemaType,
+				Timeout = timeout,
+				ConsumerConfig = consumeStep.ConsumerConfig,
+				GroupId = consumeStep.GroupId,
+				BootstrapServers = consumeStep.BootstrapServers
+			};
 
-		scenario.SetCurrentStep(newStep);
+			scenario.SetCurrentStep(newStep);
+		}
+		else if (scenario.CurrentStep is KafkaProduceStep produceStep)
+		{
+			// Create new step with updated timeout (immutable pattern)
+			var newStep = new KafkaProduceStep
+			{
+				Topic = produceStep.Topic,
+				Key = produceStep.Key,
+				Value = produceStep.Value,
+				Headers = produceStep.Headers,
+				Partition = produceStep.Partition,
+				Timestamp = produceStep.Timestamp,
+				Timeout = timeout,
+				ProducerConfig = produceStep.ProducerConfig,
+				BootstrapServers = produceStep.BootstrapServers,
+				AuthConfig = produceStep.AuthConfig,
+				JsonOptions = produceStep.JsonOptions
+			};
+
+			scenario.SetCurrentStep(newStep);
+		}
+		else
+		{
+			throw new InvalidOperationException("Current step is not a Kafka step.");
+		}
+
 		return scenario;
 	}
 
@@ -97,21 +125,46 @@ public static class KafkaScenarioExtensions
 	/// </summary>
 	public static ITestScenario WithBootstrapServers(this ITestScenario scenario, string bootstrapServers)
 	{
-		if (scenario.CurrentStep is not KafkaConsumeStep currentStep)
-			throw new InvalidOperationException("Current step is not a Kafka consume step.");
-
-		// Create new step with updated bootstrap servers (immutable pattern)
-		var newStep = new KafkaConsumeStep
+		if (scenario.CurrentStep is KafkaConsumeStep consumeStep)
 		{
-			Topic = currentStep.Topic,
-			SchemaType = currentStep.SchemaType,
-			Timeout = currentStep.Timeout,
-			ConsumerConfig = currentStep.ConsumerConfig,
-			GroupId = currentStep.GroupId,
-			BootstrapServers = bootstrapServers
-		};
+			// Create new step with updated bootstrap servers (immutable pattern)
+			var newStep = new KafkaConsumeStep
+			{
+				Topic = consumeStep.Topic,
+				SchemaType = consumeStep.SchemaType,
+				Timeout = consumeStep.Timeout,
+				ConsumerConfig = consumeStep.ConsumerConfig,
+				GroupId = consumeStep.GroupId,
+				BootstrapServers = bootstrapServers
+			};
 
-		scenario.SetCurrentStep(newStep);
+			scenario.SetCurrentStep(newStep);
+		}
+		else if (scenario.CurrentStep is KafkaProduceStep produceStep)
+		{
+			// Create new step with updated bootstrap servers (immutable pattern)
+			var newStep = new KafkaProduceStep
+			{
+				Topic = produceStep.Topic,
+				Key = produceStep.Key,
+				Value = produceStep.Value,
+				Headers = produceStep.Headers,
+				Partition = produceStep.Partition,
+				Timestamp = produceStep.Timestamp,
+				Timeout = produceStep.Timeout,
+				ProducerConfig = produceStep.ProducerConfig,
+				BootstrapServers = bootstrapServers,
+				AuthConfig = produceStep.AuthConfig,
+				JsonOptions = produceStep.JsonOptions
+			};
+
+			scenario.SetCurrentStep(newStep);
+		}
+		else
+		{
+			throw new InvalidOperationException("Current step is not a Kafka step.");
+		}
+
 		return scenario;
 	}
 
@@ -161,4 +214,273 @@ public static class KafkaScenarioExtensions
 		return scenario;
 	}
 
+	// ========== PRODUCE METHODS ==========
+
+	/// <summary>
+	/// Produces a message to the Kafka topic with null key.
+	/// Must be called after Topic().
+	/// Usage: Topic("my-topic").Produce(myObject)
+	/// </summary>
+	public static ITestScenario Produce(this ITestScenario scenario, object value)
+	{
+		var topic = scenario.Context.GetProperty<string>("_KafkaTopic");
+
+		if (string.IsNullOrWhiteSpace(topic))
+			throw new InvalidOperationException("No topic specified. Call Topic() first.");
+
+		var step = new KafkaProduceStep
+		{
+			Topic = topic,
+			Value = value
+		};
+
+		scenario.SetCurrentStep(step);
+		return scenario;
+	}
+
+	/// <summary>
+	/// Produces a message to the Kafka topic with the specified key.
+	/// Must be called after Topic().
+	/// Usage: Topic("my-topic").Produce(key: "123", value: myObject)
+	/// </summary>
+	public static ITestScenario Produce(this ITestScenario scenario, object key, object value)
+	{
+		var topic = scenario.Context.GetProperty<string>("_KafkaTopic");
+
+		if (string.IsNullOrWhiteSpace(topic))
+			throw new InvalidOperationException("No topic specified. Call Topic() first.");
+
+		var step = new KafkaProduceStep
+		{
+			Topic = topic,
+			Key = key,
+			Value = value
+		};
+
+		scenario.SetCurrentStep(step);
+		return scenario;
+	}
+
+	// ========== KEY CONFIGURATION ==========
+
+	/// <summary>
+	/// Sets the message key for a Kafka produce operation.
+	/// Alternative to passing key in Produce() method.
+	/// Usage: Produce(value).WithKey("my-key")
+	/// </summary>
+	public static ITestScenario WithKey(this ITestScenario scenario, object key)
+	{
+		if (scenario.CurrentStep is not KafkaProduceStep produceStep)
+			throw new InvalidOperationException("Current step is not a Kafka produce step.");
+
+		// Create new step with updated key (immutable pattern)
+		var newStep = new KafkaProduceStep
+		{
+			Topic = produceStep.Topic,
+			Key = key,
+			Value = produceStep.Value,
+			Headers = produceStep.Headers,
+			Partition = produceStep.Partition,
+			Timestamp = produceStep.Timestamp,
+			Timeout = produceStep.Timeout,
+			ProducerConfig = produceStep.ProducerConfig,
+			BootstrapServers = produceStep.BootstrapServers,
+			AuthConfig = produceStep.AuthConfig,
+			JsonOptions = produceStep.JsonOptions
+		};
+
+		scenario.SetCurrentStep(newStep);
+		return scenario;
+	}
+
+	// ========== HEADERS CONFIGURATION ==========
+
+	/// <summary>
+	/// Sets the headers for a Kafka message.
+	/// Usage: Produce(value).WithHeaders(headers)
+	/// </summary>
+	public static ITestScenario WithHeaders(this ITestScenario scenario, Headers headers)
+	{
+		if (scenario.CurrentStep is not KafkaProduceStep produceStep)
+			throw new InvalidOperationException("Current step is not a Kafka produce step.");
+
+		// Create new step with updated headers (immutable pattern)
+		var newStep = new KafkaProduceStep
+		{
+			Topic = produceStep.Topic,
+			Key = produceStep.Key,
+			Value = produceStep.Value,
+			Headers = headers,
+			Partition = produceStep.Partition,
+			Timestamp = produceStep.Timestamp,
+			Timeout = produceStep.Timeout,
+			ProducerConfig = produceStep.ProducerConfig,
+			BootstrapServers = produceStep.BootstrapServers,
+			AuthConfig = produceStep.AuthConfig,
+			JsonOptions = produceStep.JsonOptions
+		};
+
+		scenario.SetCurrentStep(newStep);
+		return scenario;
+	}
+
+	/// <summary>
+	/// Adds a single header to the Kafka message.
+	/// Usage: Produce(value).WithHeader("correlation-id", Encoding.UTF8.GetBytes("abc"))
+	/// </summary>
+	public static ITestScenario WithHeader(this ITestScenario scenario, string name, byte[] value)
+	{
+		if (scenario.CurrentStep is not KafkaProduceStep produceStep)
+			throw new InvalidOperationException("Current step is not a Kafka produce step.");
+
+		// Get existing headers or create new
+		var headers = produceStep.Headers ?? new Headers();
+		headers.Add(name, value);
+
+		// Create new step with updated headers (immutable pattern)
+		var newStep = new KafkaProduceStep
+		{
+			Topic = produceStep.Topic,
+			Key = produceStep.Key,
+			Value = produceStep.Value,
+			Headers = headers,
+			Partition = produceStep.Partition,
+			Timestamp = produceStep.Timestamp,
+			Timeout = produceStep.Timeout,
+			ProducerConfig = produceStep.ProducerConfig,
+			BootstrapServers = produceStep.BootstrapServers,
+			AuthConfig = produceStep.AuthConfig,
+			JsonOptions = produceStep.JsonOptions
+		};
+
+		scenario.SetCurrentStep(newStep);
+		return scenario;
+	}
+
+	// ========== PARTITION/TIMESTAMP CONFIGURATION ==========
+
+	/// <summary>
+	/// Sets a specific partition for the Kafka message.
+	/// Usage: Produce(value).WithPartition(0)
+	/// </summary>
+	public static ITestScenario WithPartition(this ITestScenario scenario, int partition)
+	{
+		if (scenario.CurrentStep is not KafkaProduceStep produceStep)
+			throw new InvalidOperationException("Current step is not a Kafka produce step.");
+
+		// Create new step with updated partition (immutable pattern)
+		var newStep = new KafkaProduceStep
+		{
+			Topic = produceStep.Topic,
+			Key = produceStep.Key,
+			Value = produceStep.Value,
+			Headers = produceStep.Headers,
+			Partition = partition,
+			Timestamp = produceStep.Timestamp,
+			Timeout = produceStep.Timeout,
+			ProducerConfig = produceStep.ProducerConfig,
+			BootstrapServers = produceStep.BootstrapServers,
+			AuthConfig = produceStep.AuthConfig,
+			JsonOptions = produceStep.JsonOptions
+		};
+
+		scenario.SetCurrentStep(newStep);
+		return scenario;
+	}
+
+	/// <summary>
+	/// Sets a custom timestamp for the Kafka message.
+	/// Usage: Produce(value).WithTimestamp(DateTime.UtcNow)
+	/// </summary>
+	public static ITestScenario WithTimestamp(this ITestScenario scenario, DateTime timestamp)
+	{
+		if (scenario.CurrentStep is not KafkaProduceStep produceStep)
+			throw new InvalidOperationException("Current step is not a Kafka produce step.");
+
+		// Create new step with updated timestamp (immutable pattern)
+		var newStep = new KafkaProduceStep
+		{
+			Topic = produceStep.Topic,
+			Key = produceStep.Key,
+			Value = produceStep.Value,
+			Headers = produceStep.Headers,
+			Partition = produceStep.Partition,
+			Timestamp = timestamp,
+			Timeout = produceStep.Timeout,
+			ProducerConfig = produceStep.ProducerConfig,
+			BootstrapServers = produceStep.BootstrapServers,
+			AuthConfig = produceStep.AuthConfig,
+			JsonOptions = produceStep.JsonOptions
+		};
+
+		scenario.SetCurrentStep(newStep);
+		return scenario;
+	}
+
+	// ========== PRODUCER CONFIGURATION ==========
+
+	/// <summary>
+	/// Sets custom Kafka producer configuration.
+	/// Usage: Produce(value).WithProducerConfig(config)
+	/// </summary>
+	public static ITestScenario WithProducerConfig(this ITestScenario scenario, ProducerConfig config)
+	{
+		if (scenario.CurrentStep is not KafkaProduceStep produceStep)
+			throw new InvalidOperationException("Current step is not a Kafka produce step.");
+
+		// Create new step with updated config (immutable pattern)
+		var newStep = new KafkaProduceStep
+		{
+			Topic = produceStep.Topic,
+			Key = produceStep.Key,
+			Value = produceStep.Value,
+			Headers = produceStep.Headers,
+			Partition = produceStep.Partition,
+			Timestamp = produceStep.Timestamp,
+			Timeout = produceStep.Timeout,
+			ProducerConfig = config,
+			BootstrapServers = produceStep.BootstrapServers,
+			AuthConfig = produceStep.AuthConfig,
+			JsonOptions = produceStep.JsonOptions
+		};
+
+		scenario.SetCurrentStep(newStep);
+		return scenario;
+	}
+
+	// ========== JSON SERIALIZATION ==========
+
+	/// <summary>
+	/// Sets custom JSON serialization options for object serialization.
+	/// Usage: Produce(value).WithJsonOptions(new JsonSerializerOptions { ... })
+	/// </summary>
+	public static ITestScenario WithJsonOptions(this ITestScenario scenario, System.Text.Json.JsonSerializerOptions options)
+	{
+		if (scenario.CurrentStep is not KafkaProduceStep produceStep)
+			throw new InvalidOperationException("Current step is not a Kafka produce step.");
+
+		// Create new step with updated JSON options (immutable pattern)
+		var newStep = new KafkaProduceStep
+		{
+			Topic = produceStep.Topic,
+			Key = produceStep.Key,
+			Value = produceStep.Value,
+			Headers = produceStep.Headers,
+			Partition = produceStep.Partition,
+			Timestamp = produceStep.Timestamp,
+			Timeout = produceStep.Timeout,
+			ProducerConfig = produceStep.ProducerConfig,
+			BootstrapServers = produceStep.BootstrapServers,
+			AuthConfig = produceStep.AuthConfig,
+			JsonOptions = options
+		};
+
+		scenario.SetCurrentStep(newStep);
+		return scenario;
+	}
+
 }
+
+
+
+

--- a/src/XUnitAssured.Kafka/Extensions/KafkaValidationExtensions.cs
+++ b/src/XUnitAssured.Kafka/Extensions/KafkaValidationExtensions.cs
@@ -74,4 +74,75 @@ public static class KafkaValidationExtensions
 
 		return scenario;
 	}
+
+	// ========== PRODUCE VALIDATIONS ==========
+
+	/// <summary>
+	/// Validates that the Kafka produce operation was successful.
+	/// Checks that Status == Persisted.
+	/// Usage: Produce(value).Then().ValidateProduceSuccess()
+	/// </summary>
+	public static ITestScenario ValidateProduceSuccess(this ITestScenario scenario)
+	{
+		return Validate(scenario, result =>
+		{
+			if (!result.Success)
+				throw new InvalidOperationException($"Produce operation failed: {string.Join(", ", result.Errors ?? new System.Collections.Generic.List<string>())}");
+
+			if (result.Status != Confluent.Kafka.PersistenceStatus.Persisted)
+				throw new InvalidOperationException($"Message was not persisted. Status: {result.Status}");
+		});
+	}
+
+	/// <summary>
+	/// Validates the partition where the message was produced.
+	/// Usage: Produce(value).Then().ValidatePartition(0)
+	/// </summary>
+	public static ITestScenario ValidatePartition(this ITestScenario scenario, int expectedPartition)
+	{
+		return Validate(scenario, result =>
+		{
+			if (result.Partition == null)
+				throw new InvalidOperationException("Partition information is not available in the result.");
+
+			if (result.Partition != expectedPartition)
+				throw new InvalidOperationException($"Expected partition {expectedPartition} but got {result.Partition}");
+		});
+	}
+
+	/// <summary>
+	/// Validates the offset where the message was produced.
+	/// Usage: Produce(value).Then().ValidateOffset(offset => offset > 0)
+	/// </summary>
+	public static ITestScenario ValidateOffset(this ITestScenario scenario, Func<long, bool> validation)
+	{
+		if (validation == null)
+			throw new ArgumentNullException(nameof(validation));
+
+		return Validate(scenario, result =>
+		{
+			if (result.Offset == null)
+				throw new InvalidOperationException("Offset information is not available in the result.");
+
+			if (!validation(result.Offset.Value))
+				throw new InvalidOperationException($"Offset validation failed for offset {result.Offset}");
+		});
+	}
+
+	/// <summary>
+	/// Validates the delivery status of the produced message.
+	/// Usage: Produce(value).Then().ValidateDeliveryStatus(PersistenceStatus.Persisted)
+	/// </summary>
+	public static ITestScenario ValidateDeliveryStatus(this ITestScenario scenario, Confluent.Kafka.PersistenceStatus expectedStatus)
+	{
+		return Validate(scenario, result =>
+		{
+			if (result.Status == null)
+				throw new InvalidOperationException("Delivery status is not available in the result.");
+
+			if (result.Status != expectedStatus)
+				throw new InvalidOperationException($"Expected delivery status {expectedStatus} but got {result.Status}");
+		});
+	}
 }
+

--- a/src/XUnitAssured.Kafka/Results/KafkaStepResult.cs
+++ b/src/XUnitAssured.Kafka/Results/KafkaStepResult.cs
@@ -48,6 +48,17 @@ public class KafkaStepResult : TestStepResult
 	public Headers? Headers => GetProperty<Headers>("Headers");
 
 	/// <summary>
+	/// The delivery/persistence status for produce operations.
+	/// </summary>
+	public PersistenceStatus? Status => GetProperty<string>("Status") switch
+	{
+		"Persisted" => PersistenceStatus.Persisted,
+		"PossiblyPersisted" => PersistenceStatus.PossiblyPersisted,
+		"NotPersisted" => PersistenceStatus.NotPersisted,
+		_ => null
+	};
+
+	/// <summary>
 	/// Gets the message converted to the specified type.
 	/// </summary>
 	/// <typeparam name="T">Target type for deserialization</typeparam>
@@ -172,4 +183,27 @@ public class KafkaStepResult : TestStepResult
 			}
 		};
 	}
+
+	/// <summary>
+	/// Creates a timeout result for produce operation.
+	/// </summary>
+	public static KafkaStepResult CreateProduceTimeout(string topic, TimeSpan timeout)
+	{
+		return new KafkaStepResult
+		{
+			Metadata = new StepMetadata
+			{
+				StartedAt = DateTimeOffset.UtcNow,
+				CompletedAt = DateTimeOffset.UtcNow,
+				Status = StepStatus.Failed
+			},
+			Success = false,
+			Errors = new List<string> { $"Failed to produce message to topic '{topic}' within timeout of {timeout.TotalSeconds}s" },
+			Properties = new Dictionary<string, object?>
+			{
+				["Topic"] = topic
+			}
+		};
+	}
 }
+

--- a/src/XUnitAssured.Kafka/Steps/KafkaProduceStep.cs
+++ b/src/XUnitAssured.Kafka/Steps/KafkaProduceStep.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using XUnitAssured.Core.Abstractions;
+using XUnitAssured.Core.Results;
+using XUnitAssured.Kafka.Configuration;
+using XUnitAssured.Kafka.Handlers;
+using XUnitAssured.Kafka.Results;
+
+namespace XUnitAssured.Kafka.Steps;
+
+/// <summary>
+/// Represents a Kafka message production step in a test scenario.
+/// Executes Kafka produce operations and returns KafkaStepResult.
+/// </summary>
+public class KafkaProduceStep : ITestStep
+{
+	/// <inheritdoc />
+	public string? Name { get; internal set; }
+
+	/// <inheritdoc />
+	public string StepType => "Kafka";
+
+	/// <inheritdoc />
+	public ITestStepResult? Result { get; private set; }
+
+	/// <inheritdoc />
+	public bool IsExecuted => Result != null;
+
+	/// <inheritdoc />
+	public bool IsValid { get; private set; }
+
+	/// <summary>
+	/// The Kafka topic to produce to.
+	/// </summary>
+	public string Topic { get; init; } = string.Empty;
+
+	/// <summary>
+	/// The message key. Can be string or object (will be JSON serialized).
+	/// </summary>
+	public object? Key { get; init; }
+
+	/// <summary>
+	/// The message value. Can be string or object (will be JSON serialized).
+	/// </summary>
+	public object? Value { get; init; }
+
+	/// <summary>
+	/// Optional Kafka message headers.
+	/// </summary>
+	public Headers? Headers { get; init; }
+
+	/// <summary>
+	/// Optional specific partition to produce to.
+	/// If null, Kafka will choose partition based on key or round-robin.
+	/// </summary>
+	public int? Partition { get; init; }
+
+	/// <summary>
+	/// Optional custom timestamp for the message.
+	/// If null, Kafka will use current timestamp.
+	/// </summary>
+	public DateTime? Timestamp { get; init; }
+
+	/// <summary>
+	/// Timeout for producing a message.
+	/// Default is 30 seconds.
+	/// </summary>
+	public TimeSpan Timeout { get; init; } = TimeSpan.FromSeconds(30);
+
+	/// <summary>
+	/// Kafka producer configuration.
+	/// If not provided, will use default configuration.
+	/// </summary>
+	public ProducerConfig? ProducerConfig { get; init; }
+
+	/// <summary>
+	/// Bootstrap servers for Kafka.
+	/// Default is "localhost:9092".
+	/// </summary>
+	public string BootstrapServers { get; init; } = "localhost:9092";
+
+	/// <summary>
+	/// Authentication configuration for this Kafka connection.
+	/// If null, will try to load from kafkasettings.json.
+	/// </summary>
+	public KafkaAuthConfig? AuthConfig { get; init; }
+
+	/// <summary>
+	/// JSON serialization options for object serialization.
+	/// If not provided, uses default options with camelCase naming.
+	/// </summary>
+	public JsonSerializerOptions? JsonOptions { get; init; }
+
+	/// <inheritdoc />
+	public async Task<ITestStepResult> ExecuteAsync(ITestContext context)
+	{
+		var startTime = DateTimeOffset.UtcNow;
+
+		try
+		{
+			// Build producer config
+			var config = ProducerConfig ?? new ProducerConfig
+			{
+				BootstrapServers = BootstrapServers,
+				ClientId = $"xunitassured-producer-{Guid.NewGuid():N}"
+			};
+
+			// Apply authentication
+			ApplyAuthentication(config);
+
+			// Serialize key and value to string
+			var keyString = SerializeToString(Key);
+			var valueString = SerializeToString(Value);
+
+			// Create producer
+			using var producer = new ProducerBuilder<string, string>(config).Build();
+
+			// Build message
+			var message = new Message<string, string>
+			{
+				Key = keyString,
+				Value = valueString,
+				Headers = Headers,
+				Timestamp = Timestamp.HasValue 
+					? new Confluent.Kafka.Timestamp(Timestamp.Value) 
+					: Confluent.Kafka.Timestamp.Default
+			};
+
+			// Produce message with timeout
+			DeliveryResult<string, string> deliveryResult;
+			
+			using var cts = new CancellationTokenSource(Timeout);
+
+			try
+			{
+				if (Partition.HasValue)
+				{
+					var topicPartition = new TopicPartition(Topic, new Confluent.Kafka.Partition(Partition.Value));
+					deliveryResult = await producer.ProduceAsync(topicPartition, message, cts.Token);
+				}
+				else
+				{
+					deliveryResult = await producer.ProduceAsync(Topic, message, cts.Token);
+				}
+
+				// Flush to ensure delivery
+				producer.Flush(Timeout);
+
+				// Create success result
+				Result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+				return Result;
+			}
+			catch (OperationCanceledException)
+			{
+				// Timeout
+				Result = KafkaStepResult.CreateProduceTimeout(Topic, Timeout);
+				return Result;
+			}
+		}
+		catch (Exception ex)
+		{
+			// Network error, Kafka error, etc.
+			Result = KafkaStepResult.CreateFailure(ex);
+			return Result;
+		}
+	}
+
+	/// <inheritdoc />
+	public void Validate(Action<ITestStepResult> validation)
+	{
+		if (Result == null)
+			throw new InvalidOperationException("Step must be executed before validation. Call ExecuteAsync first.");
+
+		try
+		{
+			validation(Result);
+			IsValid = true;
+		}
+		catch
+		{
+			IsValid = false;
+			throw;
+		}
+	}
+
+	/// <summary>
+	/// Serializes an object to string for Kafka message.
+	/// If the object is already a string, returns it directly.
+	/// Otherwise, serializes to JSON.
+	/// </summary>
+	private string? SerializeToString(object? obj)
+	{
+		if (obj == null)
+			return null;
+
+		if (obj is string str)
+			return str;
+
+		// Serialize object to JSON
+		var options = JsonOptions ?? new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+			WriteIndented = false
+		};
+
+		return JsonSerializer.Serialize(obj, options);
+	}
+
+	/// <summary>
+	/// Applies authentication to the producer configuration.
+	/// Uses AuthConfig if provided, otherwise loads from kafkasettings.json.
+	/// </summary>
+	private void ApplyAuthentication(ProducerConfig config)
+	{
+		// Get authentication config
+		var authConfig = AuthConfig;
+
+		// If no config provided, try to load from settings
+		if (authConfig == null)
+		{
+			var settings = KafkaSettings.Load();
+			authConfig = settings.Authentication;
+		}
+
+		// Skip if no authentication configured
+		if (authConfig == null || authConfig.Type == KafkaAuthenticationType.None)
+			return;
+
+		// Create appropriate handler and apply authentication
+		IKafkaAuthenticationHandler? handler = authConfig.Type switch
+		{
+			KafkaAuthenticationType.SaslPlain when authConfig.SaslPlain != null => new SaslPlainHandler(authConfig.SaslPlain),
+			KafkaAuthenticationType.SaslSsl when authConfig.SaslPlain != null => new SaslPlainHandler(authConfig.SaslPlain),
+			_ => null
+		};
+
+		handler?.ApplyAuthentication(config);
+	}
+}

--- a/src/XUnitAssured.Tests/KafkaTests/KafkaConsumeStepTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/KafkaConsumeStepTests.cs
@@ -105,14 +105,27 @@ public class KafkaConsumeStepTests
 		step.GroupId.ShouldBe("xunitassured-consumer");
 	}
 
-	[Fact(DisplayName = "Topic extension should create KafkaConsumeStep")]
-	public void Topic_Extension_Should_Create_KafkaStep()
+	[Fact(DisplayName = "Topic extension should store topic in context")]
+	public void Topic_Extension_Should_Store_Topic_In_Context()
 	{
 		// Arrange
 		var scenario = Given();
 
 		// Act
 		scenario.Topic("my-topic");
+
+		// Assert
+		var topic = scenario.Context.GetProperty<string>("_KafkaTopic");
+		topic.ShouldBe("my-topic");
+	}
+
+	[Fact(DisplayName = "Consume should create KafkaConsumeStep from stored topic")]
+	public void Consume_Should_Create_KafkaStep_From_Stored_Topic()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("my-topic")
+			.Consume();
 
 		// Assert
 		scenario.CurrentStep.ShouldNotBeNull();
@@ -144,7 +157,7 @@ public class KafkaConsumeStepTests
 	public void WithSchema_Should_Update_SchemaType()
 	{
 		// Arrange
-		var scenario = Given().Topic("test-topic");
+		var scenario = Given().Topic("test-topic").Consume();
 
 		// Act
 		scenario.WithSchema(typeof(string));
@@ -158,7 +171,7 @@ public class KafkaConsumeStepTests
 	public void WithTimeout_Should_Update_Timeout()
 	{
 		// Arrange
-		var scenario = Given().Topic("test-topic");
+		var scenario = Given().Topic("test-topic").Consume();
 
 		// Act
 		scenario.WithTimeout(TimeSpan.FromSeconds(60));
@@ -172,7 +185,7 @@ public class KafkaConsumeStepTests
 	public void WithBootstrapServers_Should_Update_BootstrapServers()
 	{
 		// Arrange
-		var scenario = Given().Topic("test-topic");
+		var scenario = Given().Topic("test-topic").Consume();
 
 		// Act
 		scenario.WithBootstrapServers("kafka:9092");
@@ -186,7 +199,7 @@ public class KafkaConsumeStepTests
 	public void WithGroupId_Should_Update_GroupId()
 	{
 		// Arrange
-		var scenario = Given().Topic("test-topic");
+		var scenario = Given().Topic("test-topic").Consume();
 
 		// Act
 		scenario.WithGroupId("my-consumer-group");
@@ -202,6 +215,7 @@ public class KafkaConsumeStepTests
 		// Act
 		var scenario = Given()
 			.Topic("test-topic")
+			.Consume()
 			.WithSchema(typeof(string))
 			.WithTimeout(TimeSpan.FromSeconds(45))
 			.WithBootstrapServers("kafka:9092")

--- a/src/XUnitAssured.Tests/KafkaTests/KafkaProduceAdvancedConfigTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/KafkaProduceAdvancedConfigTests.cs
@@ -1,0 +1,574 @@
+using System.Text;
+using System.Text.Json;
+using Confluent.Kafka;
+using XUnitAssured.Kafka.Steps;
+
+namespace XUnitAssured.Tests.KafkaTests;
+
+[Trait("Category", "Kafka")]
+[Trait("Component", "ProduceConfiguration")]
+/// <summary>
+/// Advanced unit tests for Kafka Produce configuration (Phase 2).
+/// Tests for headers, keys, partitioning, timestamps, and JSON serialization.
+/// </summary>
+public class KafkaProduceAdvancedConfigTests
+{
+	#region WithKey Advanced Tests
+
+	[Fact(DisplayName = "WithKey should accept string key")]
+	public void WithKey_Should_Accept_String_Key()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithKey("string-key");
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBe("string-key");
+		step.Key.ShouldBeOfType<string>();
+	}
+
+	[Fact(DisplayName = "WithKey should accept integer key")]
+	public void WithKey_Should_Accept_Integer_Key()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithKey(12345);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBe(12345);
+		step.Key.ShouldBeOfType<int>();
+	}
+
+	[Fact(DisplayName = "WithKey should accept GUID key")]
+	public void WithKey_Should_Accept_Guid_Key()
+	{
+		// Arrange
+		var guid = Guid.NewGuid();
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithKey(guid);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBe(guid);
+	}
+
+	[Fact(DisplayName = "WithKey should accept complex object key")]
+	public void WithKey_Should_Accept_Complex_Object_Key()
+	{
+		// Arrange
+		var complexKey = new { TenantId = "ABC", OrderId = "123", Region = "US-EAST" };
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithKey(complexKey);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBe(complexKey);
+	}
+
+	[Fact(DisplayName = "WithKey should replace existing key")]
+	public void WithKey_Should_Replace_Existing_Key()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("key-1", "test-value")
+			.WithKey("key-2");
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBe("key-2");
+	}
+
+	[Fact(DisplayName = "WithKey should accept null key")]
+	public void WithKey_Should_Accept_Null_Key()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("key-1", "test-value")
+			.WithKey(null);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBeNull();
+	}
+
+	#endregion
+
+	#region WithHeaders Advanced Tests
+
+	[Fact(DisplayName = "WithHeaders should replace all existing headers")]
+	public void WithHeaders_Should_Replace_All_Existing_Headers()
+	{
+		// Arrange
+		var oldHeaders = new Headers();
+		oldHeaders.Add("old-header", Encoding.UTF8.GetBytes("old-value"));
+
+		var newHeaders = new Headers();
+		newHeaders.Add("new-header", Encoding.UTF8.GetBytes("new-value"));
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeaders(oldHeaders)
+			.WithHeaders(newHeaders);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldBe(newHeaders);
+		step.Headers!.Count.ShouldBe(1);
+		step.Headers[0].Key.ShouldBe("new-header");
+	}
+
+	[Fact(DisplayName = "WithHeaders should accept empty headers")]
+	public void WithHeaders_Should_Accept_Empty_Headers()
+	{
+		// Arrange
+		var emptyHeaders = new Headers();
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeaders(emptyHeaders);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		step.Headers!.Count.ShouldBe(0);
+	}
+
+	[Fact(DisplayName = "WithHeader should append multiple headers sequentially")]
+	public void WithHeader_Should_Append_Multiple_Headers_Sequentially()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeader("correlation-id", Encoding.UTF8.GetBytes("abc-123"))
+			.WithHeader("event-type", Encoding.UTF8.GetBytes("OrderCreated"))
+			.WithHeader("tenant-id", Encoding.UTF8.GetBytes("tenant-001"))
+			.WithHeader("version", Encoding.UTF8.GetBytes("v1"));
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		step.Headers!.Count.ShouldBe(4);
+		step.Headers[0].Key.ShouldBe("correlation-id");
+		step.Headers[1].Key.ShouldBe("event-type");
+		step.Headers[2].Key.ShouldBe("tenant-id");
+		step.Headers[3].Key.ShouldBe("version");
+	}
+
+	[Fact(DisplayName = "WithHeader should handle binary header values")]
+	public void WithHeader_Should_Handle_Binary_Header_Values()
+	{
+		// Arrange
+		var binaryData = new byte[] { 0x01, 0x02, 0x03, 0xFF, 0xFE };
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeader("binary-data", binaryData);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		var header = step.Headers![0];
+		header.GetValueBytes().ShouldBe(binaryData);
+	}
+
+	[Fact(DisplayName = "WithHeader should handle empty header value")]
+	public void WithHeader_Should_Handle_Empty_Header_Value()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeader("empty-header", Array.Empty<byte>());
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		step.Headers!.Count.ShouldBe(1);
+		step.Headers[0].GetValueBytes().Length.ShouldBe(0);
+	}
+
+	[Fact(DisplayName = "WithHeader should handle very long header names")]
+	public void WithHeader_Should_Handle_Long_Header_Names()
+	{
+		// Arrange
+		var longHeaderName = new string('x', 1000);
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeader(longHeaderName, Encoding.UTF8.GetBytes("value"));
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		step.Headers![0].Key.ShouldBe(longHeaderName);
+		step.Headers[0].Key.Length.ShouldBe(1000);
+	}
+
+	[Fact(DisplayName = "WithHeader should allow duplicate header keys")]
+	public void WithHeader_Should_Allow_Duplicate_Header_Keys()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeader("duplicate", Encoding.UTF8.GetBytes("value1"))
+			.WithHeader("duplicate", Encoding.UTF8.GetBytes("value2"));
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		step.Headers!.Count.ShouldBe(2);
+		step.Headers[0].Key.ShouldBe("duplicate");
+		step.Headers[1].Key.ShouldBe("duplicate");
+		Encoding.UTF8.GetString(step.Headers[0].GetValueBytes()).ShouldBe("value1");
+		Encoding.UTF8.GetString(step.Headers[1].GetValueBytes()).ShouldBe("value2");
+	}
+
+	#endregion
+
+	#region WithPartition Advanced Tests
+
+	[Fact(DisplayName = "WithPartition should accept partition 0")]
+	public void WithPartition_Should_Accept_Partition_Zero()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithPartition(0);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Partition.ShouldBe(0);
+	}
+
+	[Fact(DisplayName = "WithPartition should accept high partition numbers")]
+	public void WithPartition_Should_Accept_High_Partition_Numbers()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithPartition(999);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Partition.ShouldBe(999);
+	}
+
+	[Fact(DisplayName = "WithPartition should replace existing partition")]
+	public void WithPartition_Should_Replace_Existing_Partition()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithPartition(1)
+			.WithPartition(5);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Partition.ShouldBe(5);
+	}
+
+	#endregion
+
+	#region WithTimestamp Advanced Tests
+
+	[Fact(DisplayName = "WithTimestamp should accept past timestamp")]
+	public void WithTimestamp_Should_Accept_Past_Timestamp()
+	{
+		// Arrange
+		var pastTimestamp = DateTime.UtcNow.AddHours(-24);
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithTimestamp(pastTimestamp);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Timestamp.ShouldBe(pastTimestamp);
+	}
+
+	[Fact(DisplayName = "WithTimestamp should accept future timestamp")]
+	public void WithTimestamp_Should_Accept_Future_Timestamp()
+	{
+		// Arrange
+		var futureTimestamp = DateTime.UtcNow.AddHours(24);
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithTimestamp(futureTimestamp);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Timestamp.ShouldBe(futureTimestamp);
+	}
+
+	[Fact(DisplayName = "WithTimestamp should accept epoch timestamp")]
+	public void WithTimestamp_Should_Accept_Epoch_Timestamp()
+	{
+		// Arrange
+		var epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithTimestamp(epoch);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Timestamp.ShouldBe(epoch);
+	}
+
+	[Fact(DisplayName = "WithTimestamp should replace existing timestamp")]
+	public void WithTimestamp_Should_Replace_Existing_Timestamp()
+	{
+		// Arrange
+		var timestamp1 = DateTime.UtcNow.AddHours(-1);
+		var timestamp2 = DateTime.UtcNow;
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithTimestamp(timestamp1)
+			.WithTimestamp(timestamp2);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Timestamp.ShouldBe(timestamp2);
+	}
+
+	#endregion
+
+	#region JSON Serialization Tests
+
+	[Fact(DisplayName = "Produce should handle nested object serialization")]
+	public void Produce_Should_Handle_Nested_Object_Serialization()
+	{
+		// Arrange
+		var nestedObject = new
+		{
+			OrderId = "123",
+			Customer = new
+			{
+				Id = "C001",
+				Name = "John Doe",
+				Address = new
+				{
+					Street = "123 Main St",
+					City = "New York",
+					ZipCode = "10001"
+				}
+			},
+			Items = new[]
+			{
+				new { ProductId = "P1", Quantity = 2 },
+				new { ProductId = "P2", Quantity = 1 }
+			}
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(nestedObject);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Value.ShouldBe(nestedObject);
+	}
+
+	[Fact(DisplayName = "Produce should handle array values")]
+	public void Produce_Should_Handle_Array_Values()
+	{
+		// Arrange
+		var arrayValue = new[] { 1, 2, 3, 4, 5 };
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(arrayValue);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Value.ShouldBe(arrayValue);
+	}
+
+	[Fact(DisplayName = "Produce should handle null value")]
+	public void Produce_Should_Handle_Null_Value()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(null!);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Value.ShouldBeNull();
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should customize serialization")]
+	public void WithJsonOptions_Should_Customize_Serialization()
+	{
+		// Arrange
+		var customOptions = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+			WriteIndented = true
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { FirstName = "John", LastName = "Doe" })
+			.WithJsonOptions(customOptions);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions.ShouldBe(customOptions);
+		step.JsonOptions!.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.SnakeCaseLower);
+		step.JsonOptions.WriteIndented.ShouldBeTrue();
+	}
+
+	#endregion
+
+	#region Immutability Tests
+
+	[Fact(DisplayName = "All With methods should maintain immutability pattern")]
+	public void All_With_Methods_Should_Maintain_Immutability()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var originalStep = scenario.CurrentStep;
+
+		// Act - Call all With methods
+		scenario
+			.WithKey("new-key")
+			.WithHeader("header1", Encoding.UTF8.GetBytes("value1"))
+			.WithPartition(3)
+			.WithTimestamp(DateTime.UtcNow)
+			.WithTimeout(TimeSpan.FromSeconds(60))
+			.WithBootstrapServers("kafka:9092")
+			.WithProducerConfig(new ProducerConfig())
+			.WithJsonOptions(new JsonSerializerOptions());
+
+		var finalStep = scenario.CurrentStep;
+
+		// Assert
+		originalStep.ShouldNotBe(finalStep);
+		((KafkaProduceStep)originalStep).Key.ShouldBeNull();
+		((KafkaProduceStep)finalStep).Key.ShouldBe("new-key");
+	}
+
+	[Fact(DisplayName = "WithKey should preserve all other properties")]
+	public void WithKey_Should_Preserve_All_Other_Properties()
+	{
+		// Arrange
+		var headers = new Headers();
+		headers.Add("test", Encoding.UTF8.GetBytes("value"));
+
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithHeaders(headers)
+			.WithPartition(2)
+			.WithTimestamp(DateTime.UtcNow)
+			.WithTimeout(TimeSpan.FromSeconds(45))
+			.WithBootstrapServers("kafka:9092");
+
+		var stepBeforeKey = (KafkaProduceStep)scenario.CurrentStep;
+
+		// Act
+		scenario.WithKey("new-key");
+		var stepAfterKey = (KafkaProduceStep)scenario.CurrentStep;
+
+		// Assert
+		stepAfterKey.Topic.ShouldBe(stepBeforeKey.Topic);
+		stepAfterKey.Value.ShouldBe(stepBeforeKey.Value);
+		stepAfterKey.Headers.ShouldBe(stepBeforeKey.Headers);
+		stepAfterKey.Partition.ShouldBe(stepBeforeKey.Partition);
+		stepAfterKey.Timestamp.ShouldBe(stepBeforeKey.Timestamp);
+		stepAfterKey.Timeout.ShouldBe(stepBeforeKey.Timeout);
+		stepAfterKey.BootstrapServers.ShouldBe(stepBeforeKey.BootstrapServers);
+	}
+
+	#endregion
+
+	#region Complex Integration Tests
+
+	[Fact(DisplayName = "Should support full message configuration chain")]
+	public void Should_Support_Full_Message_Configuration_Chain()
+	{
+		// Arrange
+		var timestamp = DateTime.UtcNow;
+		var complexValue = new
+		{
+			EventId = Guid.NewGuid(),
+			Type = "OrderCreated",
+			Payload = new { OrderId = "123", Amount = 99.99m }
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("events")
+			.Produce(complexValue)
+			.WithKey("order-123")
+			.WithHeader("correlation-id", Encoding.UTF8.GetBytes("abc-123"))
+			.WithHeader("event-type", Encoding.UTF8.GetBytes("OrderCreated"))
+			.WithHeader("schema-version", Encoding.UTF8.GetBytes("v1"))
+			.WithPartition(2)
+			.WithTimestamp(timestamp)
+			.WithTimeout(TimeSpan.FromSeconds(30))
+			.WithBootstrapServers("kafka:9092")
+			.WithJsonOptions(new JsonSerializerOptions
+			{
+				PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+			});
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Topic.ShouldBe("events");
+		step.Key.ShouldBe("order-123");
+		step.Value.ShouldBe(complexValue);
+		step.Headers.ShouldNotBeNull();
+		step.Headers!.Count.ShouldBe(3);
+		step.Partition.ShouldBe(2);
+		step.Timestamp.ShouldBe(timestamp);
+		step.Timeout.ShouldBe(TimeSpan.FromSeconds(30));
+		step.BootstrapServers.ShouldBe("kafka:9092");
+		step.JsonOptions.ShouldNotBeNull();
+	}
+
+	#endregion
+}

--- a/src/XUnitAssured.Tests/KafkaTests/KafkaProduceStepTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/KafkaProduceStepTests.cs
@@ -1,0 +1,626 @@
+using System.Text;
+using System.Text.Json;
+using Confluent.Kafka;
+using XUnitAssured.Kafka.Steps;
+
+namespace XUnitAssured.Tests.KafkaTests;
+
+[Trait("Category", "Kafka")]
+[Trait("Component", "ProduceStep")]
+/// <summary>
+/// Unit tests for KafkaProduceStep and Kafka Produce DSL.
+/// Note: These are unit tests for the step structure, not integration tests.
+/// Integration tests with real Kafka require a running Kafka instance.
+/// </summary>
+public class KafkaProduceStepTests
+{
+	#region Basic Properties Tests
+
+	[Fact(DisplayName = "KafkaProduceStep should have correct StepType value")]
+	public void KafkaProduceStep_Should_Have_Correct_StepType()
+	{
+		// Arrange & Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test-value"
+		};
+
+		// Assert
+		step.StepType.ShouldBe("Kafka");
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should store topic name correctly")]
+	public void KafkaProduceStep_Should_Store_Topic()
+	{
+		// Arrange & Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "my-topic",
+			Value = "test"
+		};
+
+		// Assert
+		step.Topic.ShouldBe("my-topic");
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should store key correctly")]
+	public void KafkaProduceStep_Should_Store_Key()
+	{
+		// Arrange & Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Key = "my-key",
+			Value = "test-value"
+		};
+
+		// Assert
+		step.Key.ShouldBe("my-key");
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should store value correctly")]
+	public void KafkaProduceStep_Should_Store_Value()
+	{
+		// Arrange
+		var testValue = new { Id = 1, Name = "Test" };
+
+		// Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = testValue
+		};
+
+		// Assert
+		step.Value.ShouldBe(testValue);
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should have default timeout of 30 seconds")]
+	public void KafkaProduceStep_Should_Have_Default_Timeout()
+	{
+		// Arrange & Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test"
+		};
+
+		// Assert
+		step.Timeout.ShouldBe(TimeSpan.FromSeconds(30));
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should allow custom timeout configuration")]
+	public void KafkaProduceStep_Should_Allow_Custom_Timeout()
+	{
+		// Arrange & Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test",
+			Timeout = TimeSpan.FromSeconds(60)
+		};
+
+		// Assert
+		step.Timeout.ShouldBe(TimeSpan.FromSeconds(60));
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should have default bootstrap servers")]
+	public void KafkaProduceStep_Should_Have_Default_BootstrapServers()
+	{
+		// Arrange & Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test"
+		};
+
+		// Assert
+		step.BootstrapServers.ShouldBe("localhost:9092");
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should store headers correctly")]
+	public void KafkaProduceStep_Should_Store_Headers()
+	{
+		// Arrange
+		var headers = new Headers();
+		headers.Add("correlation-id", Encoding.UTF8.GetBytes("123"));
+
+		// Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test",
+			Headers = headers
+		};
+
+		// Assert
+		step.Headers.ShouldNotBeNull();
+		step.Headers.Count.ShouldBe(1);
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should store partition correctly")]
+	public void KafkaProduceStep_Should_Store_Partition()
+	{
+		// Arrange & Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test",
+			Partition = 2
+		};
+
+		// Assert
+		step.Partition.ShouldBe(2);
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should store timestamp correctly")]
+	public void KafkaProduceStep_Should_Store_Timestamp()
+	{
+		// Arrange
+		var timestamp = DateTime.UtcNow;
+
+		// Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test",
+			Timestamp = timestamp
+		};
+
+		// Assert
+		step.Timestamp.ShouldBe(timestamp);
+	}
+
+	[Fact(DisplayName = "KafkaProduceStep should store JsonOptions correctly")]
+	public void KafkaProduceStep_Should_Store_JsonOptions()
+	{
+		// Arrange
+		var jsonOptions = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+		};
+
+		// Act
+		var step = new KafkaProduceStep
+		{
+			Topic = "test-topic",
+			Value = "test",
+			JsonOptions = jsonOptions
+		};
+
+		// Assert
+		step.JsonOptions.ShouldBe(jsonOptions);
+	}
+
+	#endregion
+
+	#region DSL Extension Tests
+
+	[Fact(DisplayName = "Produce extension should create KafkaProduceStep with value only")]
+	public void Produce_Extension_Should_Create_ProduceStep_With_Value()
+	{
+		// Arrange
+		var scenario = Given().Topic("my-topic");
+		var value = new { Id = 1, Name = "Test" };
+
+		// Act
+		scenario.Produce(value);
+
+		// Assert
+		scenario.CurrentStep.ShouldNotBeNull();
+		scenario.CurrentStep.ShouldBeOfType<KafkaProduceStep>();
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Topic.ShouldBe("my-topic");
+		step.Value.ShouldBe(value);
+		step.Key.ShouldBeNull();
+	}
+
+	[Fact(DisplayName = "Produce extension should create KafkaProduceStep with key and value")]
+	public void Produce_Extension_Should_Create_ProduceStep_With_Key_And_Value()
+	{
+		// Arrange
+		var scenario = Given().Topic("my-topic");
+		var key = "order-123";
+		var value = new { OrderId = "123", Amount = 99.99 };
+
+		// Act
+		scenario.Produce(key, value);
+
+		// Assert
+		scenario.CurrentStep.ShouldNotBeNull();
+		scenario.CurrentStep.ShouldBeOfType<KafkaProduceStep>();
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Topic.ShouldBe("my-topic");
+		step.Key.ShouldBe(key);
+		step.Value.ShouldBe(value);
+	}
+
+	[Fact(DisplayName = "Produce extension should throw InvalidOperationException when no topic specified")]
+	public void Produce_Extension_Should_Throw_When_No_Topic()
+	{
+		// Arrange
+		var scenario = Given();
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() => scenario.Produce("test"));
+	}
+
+	[Fact(DisplayName = "Topic extension should store topic in context for Produce")]
+	public void Topic_Extension_Should_Store_Topic_In_Context_For_Produce()
+	{
+		// Arrange
+		var scenario = Given();
+
+		// Act
+		scenario.Topic("my-topic").Produce("test-value");
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Topic.ShouldBe("my-topic");
+	}
+
+	#endregion
+
+	#region Key and Headers Configuration Tests
+
+	[Fact(DisplayName = "WithKey should update key in KafkaProduceStep")]
+	public void WithKey_Should_Update_Key()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+
+		// Act
+		scenario.WithKey("my-key");
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBe("my-key");
+	}
+
+	[Fact(DisplayName = "WithKey should throw InvalidOperationException for non-produce step")]
+	public void WithKey_Should_Throw_For_Non_Produce_Step()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Consume();
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() => scenario.WithKey("key"));
+	}
+
+	[Fact(DisplayName = "WithHeaders should update headers in KafkaProduceStep")]
+	public void WithHeaders_Should_Update_Headers()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var headers = new Headers();
+		headers.Add("correlation-id", Encoding.UTF8.GetBytes("123"));
+
+		// Act
+		scenario.WithHeaders(headers);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldBe(headers);
+	}
+
+	[Fact(DisplayName = "WithHeader should add single header to KafkaProduceStep")]
+	public void WithHeader_Should_Add_Single_Header()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var headerValue = Encoding.UTF8.GetBytes("correlation-123");
+
+		// Act
+		scenario.WithHeader("correlation-id", headerValue);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		step.Headers.Count.ShouldBe(1);
+		var header = step.Headers[0];
+		header.Key.ShouldBe("correlation-id");
+		Encoding.UTF8.GetString(header.GetValueBytes()).ShouldBe("correlation-123");
+	}
+
+	[Fact(DisplayName = "WithHeader should append multiple headers")]
+	public void WithHeader_Should_Append_Multiple_Headers()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+
+		// Act
+		scenario
+			.WithHeader("correlation-id", Encoding.UTF8.GetBytes("123"))
+			.WithHeader("event-type", Encoding.UTF8.GetBytes("OrderCreated"));
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Headers.ShouldNotBeNull();
+		step.Headers.Count.ShouldBe(2);
+	}
+
+	[Fact(DisplayName = "WithHeader should throw InvalidOperationException for non-produce step")]
+	public void WithHeader_Should_Throw_For_Non_Produce_Step()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Consume();
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() => 
+			scenario.WithHeader("key", Encoding.UTF8.GetBytes("value")));
+	}
+
+	#endregion
+
+	#region Partition and Timestamp Configuration Tests
+
+	[Fact(DisplayName = "WithPartition should update partition in KafkaProduceStep")]
+	public void WithPartition_Should_Update_Partition()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+
+		// Act
+		scenario.WithPartition(2);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Partition.ShouldBe(2);
+	}
+
+	[Fact(DisplayName = "WithPartition should throw InvalidOperationException for non-produce step")]
+	public void WithPartition_Should_Throw_For_Non_Produce_Step()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Consume();
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() => scenario.WithPartition(0));
+	}
+
+	[Fact(DisplayName = "WithTimestamp should update timestamp in KafkaProduceStep")]
+	public void WithTimestamp_Should_Update_Timestamp()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var timestamp = DateTime.UtcNow.AddHours(-1);
+
+		// Act
+		scenario.WithTimestamp(timestamp);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Timestamp.ShouldBe(timestamp);
+	}
+
+	[Fact(DisplayName = "WithTimestamp should throw InvalidOperationException for non-produce step")]
+	public void WithTimestamp_Should_Throw_For_Non_Produce_Step()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Consume();
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() => scenario.WithTimestamp(DateTime.UtcNow));
+	}
+
+	#endregion
+
+	#region ProducerConfig and JsonOptions Tests
+
+	[Fact(DisplayName = "WithProducerConfig should update producer config in KafkaProduceStep")]
+	public void WithProducerConfig_Should_Update_Config()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			MessageMaxBytes = 1048576
+		};
+
+		// Act
+		scenario.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig.ShouldBe(config);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should throw InvalidOperationException for non-produce step")]
+	public void WithProducerConfig_Should_Throw_For_Non_Produce_Step()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Consume();
+		var config = new ProducerConfig();
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() => scenario.WithProducerConfig(config));
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should update JSON options in KafkaProduceStep")]
+	public void WithJsonOptions_Should_Update_JsonOptions()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var jsonOptions = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+		};
+
+		// Act
+		scenario.WithJsonOptions(jsonOptions);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions.ShouldBe(jsonOptions);
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should throw InvalidOperationException for non-produce step")]
+	public void WithJsonOptions_Should_Throw_For_Non_Produce_Step()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Consume();
+		var jsonOptions = new JsonSerializerOptions();
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() => scenario.WithJsonOptions(jsonOptions));
+	}
+
+	#endregion
+
+	#region Timeout and BootstrapServers Tests
+
+	[Fact(DisplayName = "WithTimeout should update timeout in KafkaProduceStep")]
+	public void WithTimeout_Should_Update_Timeout_For_Produce()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+
+		// Act
+		scenario.WithTimeout(TimeSpan.FromSeconds(60));
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Timeout.ShouldBe(TimeSpan.FromSeconds(60));
+	}
+
+	[Fact(DisplayName = "WithBootstrapServers should update bootstrap servers in KafkaProduceStep")]
+	public void WithBootstrapServers_Should_Update_BootstrapServers_For_Produce()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+
+		// Act
+		scenario.WithBootstrapServers("kafka:9092");
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.BootstrapServers.ShouldBe("kafka:9092");
+	}
+
+	#endregion
+
+	#region Fluent DSL Integration Tests
+
+	[Fact(DisplayName = "Kafka Produce DSL should chain fluently with all configuration methods")]
+	public void Kafka_Produce_DSL_Should_Chain_Fluently()
+	{
+		// Arrange
+		var timestamp = DateTime.UtcNow;
+		var jsonOptions = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("order-123", new { OrderId = "123", Amount = 99.99 })
+			.WithHeader("correlation-id", Encoding.UTF8.GetBytes("abc-123"))
+			.WithPartition(2)
+			.WithTimestamp(timestamp)
+			.WithTimeout(TimeSpan.FromSeconds(45))
+			.WithBootstrapServers("kafka:9092")
+			.WithJsonOptions(jsonOptions);
+
+		// Assert
+		scenario.ShouldNotBeNull();
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Topic.ShouldBe("test-topic");
+		step.Key.ShouldBe("order-123");
+		step.Value.ShouldNotBeNull();
+		step.Headers.ShouldNotBeNull();
+		step.Headers.Count.ShouldBe(1);
+		step.Partition.ShouldBe(2);
+		step.Timestamp.ShouldBe(timestamp);
+		step.Timeout.ShouldBe(TimeSpan.FromSeconds(45));
+		step.BootstrapServers.ShouldBe("kafka:9092");
+		step.JsonOptions.ShouldBe(jsonOptions);
+	}
+
+	[Fact(DisplayName = "Kafka DSL should support produce and consume in same scenario")]
+	public void Kafka_DSL_Should_Support_Produce_And_Consume()
+	{
+		// Act
+		var scenario = Given()
+			.Topic("orders")
+			.Produce(new { OrderId = "123" })
+		.When()
+			.And()
+		.Then()
+			.Topic("order-confirmations")
+			.Consume();
+
+		// Assert
+		scenario.ShouldNotBeNull();
+		// Last step should be consume
+		scenario.CurrentStep.ShouldBeOfType<KafkaConsumeStep>();
+	}
+
+	[Fact(DisplayName = "Kafka DSL should maintain immutability pattern for all With methods")]
+	public void Kafka_DSL_Should_Maintain_Immutability()
+	{
+		// Arrange
+		var scenario = Given().Topic("test-topic").Produce("test");
+		var originalStep = scenario.CurrentStep;
+
+		// Act
+		scenario.WithKey("new-key");
+		var newStep = scenario.CurrentStep;
+
+		// Assert
+		originalStep.ShouldNotBe(newStep);
+		((KafkaProduceStep)originalStep).Key.ShouldBeNull();
+		((KafkaProduceStep)newStep).Key.ShouldBe("new-key");
+	}
+
+	[Fact(DisplayName = "Produce with string value should store value correctly")]
+	public void Produce_With_String_Should_Store_Correctly()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("simple string message");
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Value.ShouldBe("simple string message");
+	}
+
+	[Fact(DisplayName = "Produce with object value should store value correctly")]
+	public void Produce_With_Object_Should_Store_Correctly()
+	{
+		// Arrange
+		var order = new { OrderId = "123", Amount = 99.99m, Status = "Pending" };
+
+		// Act
+		var scenario = Given()
+			.Topic("orders")
+			.Produce(order);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Value.ShouldBe(order);
+	}
+
+	[Fact(DisplayName = "Produce with complex key should store key correctly")]
+	public void Produce_With_Complex_Key_Should_Store_Correctly()
+	{
+		// Arrange
+		var key = new { TenantId = "ABC", OrderId = "123" };
+		var value = new { Amount = 99.99 };
+
+		// Act
+		var scenario = Given()
+			.Topic("orders")
+			.Produce(key, value);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.Key.ShouldBe(key);
+		step.Value.ShouldBe(value);
+	}
+
+	#endregion
+}

--- a/src/XUnitAssured.Tests/KafkaTests/KafkaProduceValidationTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/KafkaProduceValidationTests.cs
@@ -1,0 +1,455 @@
+using Confluent.Kafka;
+using XUnitAssured.Kafka.Results;
+
+namespace XUnitAssured.Tests.KafkaTests;
+
+[Trait("Category", "Kafka")]
+[Trait("Component", "ProduceValidation")]
+/// <summary>
+/// Unit tests for Kafka Produce validation extensions.
+/// Tests validation methods specific to produce operations.
+/// </summary>
+public class KafkaProduceValidationTests
+{
+	#region ValidateProduceSuccess Tests
+
+	[Fact(DisplayName = "ValidateProduceSuccess should pass for successful persisted message")]
+	public void ValidateProduceSuccess_Should_Pass_For_Persisted_Message()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(123),
+			Status = PersistenceStatus.Persisted,
+			Message = new Message<string, string>
+			{
+				Key = "key",
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert - Should not throw
+		Should.NotThrow(() =>
+		{
+			if (!result.Success)
+				throw new InvalidOperationException("Produce operation failed");
+			if (result.Status != PersistenceStatus.Persisted)
+				throw new InvalidOperationException($"Message was not persisted. Status: {result.Status}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidateProduceSuccess should fail for non-persisted message")]
+	public void ValidateProduceSuccess_Should_Fail_For_Non_Persisted()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(-1),
+			Status = PersistenceStatus.NotPersisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() =>
+		{
+			if (!result.Success)
+				throw new InvalidOperationException("Produce operation failed");
+			if (result.Status != PersistenceStatus.Persisted)
+				throw new InvalidOperationException($"Message was not persisted. Status: {result.Status}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidateProduceSuccess should fail for failed result")]
+	public void ValidateProduceSuccess_Should_Fail_For_Failed_Result()
+	{
+		// Arrange
+		var result = KafkaStepResult.CreateFailure(new Exception("Produce failed"));
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() =>
+		{
+			if (!result.Success)
+				throw new InvalidOperationException("Produce operation failed");
+		});
+	}
+
+	#endregion
+
+	#region ValidatePartition Tests
+
+	[Fact(DisplayName = "ValidatePartition should pass for correct partition")]
+	public void ValidatePartition_Should_Pass_For_Correct_Partition()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(2),
+			Offset = new Offset(123),
+			Status = PersistenceStatus.Persisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert - Should not throw
+		Should.NotThrow(() =>
+		{
+			if (result.Partition == null)
+				throw new InvalidOperationException("Partition information is not available");
+			if (result.Partition != 2)
+				throw new InvalidOperationException($"Expected partition 2 but got {result.Partition}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidatePartition should fail for wrong partition")]
+	public void ValidatePartition_Should_Fail_For_Wrong_Partition()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(1),
+			Offset = new Offset(123),
+			Status = PersistenceStatus.Persisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() =>
+		{
+			if (result.Partition == null)
+				throw new InvalidOperationException("Partition information is not available");
+			if (result.Partition != 2)
+				throw new InvalidOperationException($"Expected partition 2 but got {result.Partition}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidatePartition should fail when partition is null")]
+	public void ValidatePartition_Should_Fail_When_Partition_Null()
+	{
+		// Arrange
+		var result = new KafkaStepResult
+		{
+			Success = true,
+			Properties = new Dictionary<string, object?>
+			{
+				["Topic"] = "test-topic"
+			}
+		};
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() =>
+		{
+			if (result.Partition == null)
+				throw new InvalidOperationException("Partition information is not available");
+		});
+	}
+
+	#endregion
+
+	#region ValidateOffset Tests
+
+	[Fact(DisplayName = "ValidateOffset should pass for valid offset")]
+	public void ValidateOffset_Should_Pass_For_Valid_Offset()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(12345),
+			Status = PersistenceStatus.Persisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert - Should not throw
+		Should.NotThrow(() =>
+		{
+			if (result.Offset == null)
+				throw new InvalidOperationException("Offset information is not available");
+			if (!(result.Offset > 0))
+				throw new InvalidOperationException($"Offset validation failed for offset {result.Offset}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidateOffset should fail for invalid offset")]
+	public void ValidateOffset_Should_Fail_For_Invalid_Offset()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(-1),
+			Status = PersistenceStatus.NotPersisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() =>
+		{
+			if (result.Offset == null)
+				throw new InvalidOperationException("Offset information is not available");
+			if (!(result.Offset > 0))
+				throw new InvalidOperationException($"Offset validation failed for offset {result.Offset}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidateOffset should fail when offset is null")]
+	public void ValidateOffset_Should_Fail_When_Offset_Null()
+	{
+		// Arrange
+		var result = new KafkaStepResult
+		{
+			Success = true,
+			Properties = new Dictionary<string, object?>
+			{
+				["Topic"] = "test-topic"
+			}
+		};
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() =>
+		{
+			if (result.Offset == null)
+				throw new InvalidOperationException("Offset information is not available");
+		});
+	}
+
+	[Fact(DisplayName = "ValidateOffset should support custom validation logic")]
+	public void ValidateOffset_Should_Support_Custom_Validation()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(100),
+			Status = PersistenceStatus.Persisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert - Custom validation: offset must be >= 100
+		Should.NotThrow(() =>
+		{
+			if (result.Offset == null)
+				throw new InvalidOperationException("Offset information is not available");
+			if (!(result.Offset >= 100))
+				throw new InvalidOperationException($"Offset validation failed for offset {result.Offset}");
+		});
+	}
+
+	#endregion
+
+	#region ValidateDeliveryStatus Tests
+
+	[Fact(DisplayName = "ValidateDeliveryStatus should pass for expected status")]
+	public void ValidateDeliveryStatus_Should_Pass_For_Expected_Status()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(123),
+			Status = PersistenceStatus.Persisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert - Should not throw
+		Should.NotThrow(() =>
+		{
+			if (result.Status == null)
+				throw new InvalidOperationException("Delivery status is not available");
+			if (result.Status != PersistenceStatus.Persisted)
+				throw new InvalidOperationException($"Expected delivery status Persisted but got {result.Status}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidateDeliveryStatus should fail for unexpected status")]
+	public void ValidateDeliveryStatus_Should_Fail_For_Unexpected_Status()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(-1),
+			Status = PersistenceStatus.NotPersisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert
+		Should.Throw<InvalidOperationException>(() =>
+		{
+			if (result.Status == null)
+				throw new InvalidOperationException("Delivery status is not available");
+			if (result.Status != PersistenceStatus.Persisted)
+				throw new InvalidOperationException($"Expected delivery status Persisted but got {result.Status}");
+		});
+	}
+
+	[Fact(DisplayName = "ValidateDeliveryStatus should handle PossiblyPersisted status")]
+	public void ValidateDeliveryStatus_Should_Handle_PossiblyPersisted()
+	{
+		// Arrange
+		var deliveryResult = new DeliveryResult<string, string>
+		{
+			Topic = "test-topic",
+			Partition = new Partition(0),
+			Offset = new Offset(123),
+			Status = PersistenceStatus.PossiblyPersisted,
+			Message = new Message<string, string>
+			{
+				Value = "value",
+				Timestamp = new Timestamp(DateTime.UtcNow)
+			}
+		};
+
+		var result = KafkaStepResult.CreateKafkaProduceSuccess(deliveryResult);
+
+		// Act & Assert
+		result.Status.ShouldBe(PersistenceStatus.PossiblyPersisted);
+	}
+
+	#endregion
+
+	#region KafkaStepResult Status Property Tests
+
+	[Fact(DisplayName = "KafkaStepResult Status property should return correct PersistenceStatus for Persisted")]
+	public void KafkaStepResult_Status_Should_Return_Persisted()
+	{
+		// Arrange
+		var result = new KafkaStepResult
+		{
+			Success = true,
+			Properties = new Dictionary<string, object?>
+			{
+				["Status"] = "Persisted"
+			}
+		};
+
+		// Act & Assert
+		result.Status.ShouldBe(PersistenceStatus.Persisted);
+	}
+
+	[Fact(DisplayName = "KafkaStepResult Status property should return correct PersistenceStatus for NotPersisted")]
+	public void KafkaStepResult_Status_Should_Return_NotPersisted()
+	{
+		// Arrange
+		var result = new KafkaStepResult
+		{
+			Success = false,
+			Properties = new Dictionary<string, object?>
+			{
+				["Status"] = "NotPersisted"
+			}
+		};
+
+		// Act & Assert
+		result.Status.ShouldBe(PersistenceStatus.NotPersisted);
+	}
+
+	[Fact(DisplayName = "KafkaStepResult Status property should return correct PersistenceStatus for PossiblyPersisted")]
+	public void KafkaStepResult_Status_Should_Return_PossiblyPersisted()
+	{
+		// Arrange
+		var result = new KafkaStepResult
+		{
+			Success = true,
+			Properties = new Dictionary<string, object?>
+			{
+				["Status"] = "PossiblyPersisted"
+			}
+		};
+
+		// Act & Assert
+		result.Status.ShouldBe(PersistenceStatus.PossiblyPersisted);
+	}
+
+	[Fact(DisplayName = "KafkaStepResult Status property should return null for missing status")]
+	public void KafkaStepResult_Status_Should_Return_Null_For_Missing()
+	{
+		// Arrange
+		var result = new KafkaStepResult
+		{
+			Success = true,
+			Properties = new Dictionary<string, object?>()
+		};
+
+		// Act & Assert
+		result.Status.ShouldBeNull();
+	}
+
+	[Fact(DisplayName = "CreateProduceTimeout should create timeout result with correct error message")]
+	public void CreateProduceTimeout_Should_Create_Timeout_Result()
+	{
+		// Act
+		var result = KafkaStepResult.CreateProduceTimeout("test-topic", TimeSpan.FromSeconds(30));
+
+		// Assert
+		result.Success.ShouldBeFalse();
+		result.Topic.ShouldBe("test-topic");
+		result.Metadata.Status.ShouldBe(Core.Results.StepStatus.Failed);
+		result.Errors.Count.ShouldBe(1);
+		result.Errors[0].ShouldContain("test-topic");
+		result.Errors[0].ShouldContain("30");
+		result.Errors[0].ShouldContain("produce");
+	}
+
+	#endregion
+}

--- a/src/XUnitAssured.Tests/KafkaTests/KafkaProducerConfigAdvancedTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/KafkaProducerConfigAdvancedTests.cs
@@ -1,0 +1,802 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Confluent.Kafka;
+using XUnitAssured.Kafka.Steps;
+
+namespace XUnitAssured.Tests.KafkaTests;
+
+[Trait("Category", "Kafka")]
+[Trait("Component", "ProducerConfig")]
+/// <summary>
+/// Advanced unit tests for Kafka ProducerConfig and JsonOptions (Phase 3).
+/// Tests for compression, ACKs, batching, retries, and JSON serialization options.
+/// </summary>
+public class KafkaProducerConfigAdvancedTests
+{
+	#region ProducerConfig - Compression Tests
+
+	[Fact(DisplayName = "WithProducerConfig should support Gzip compression")]
+	public void WithProducerConfig_Should_Support_Gzip_Compression()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			CompressionType = CompressionType.Gzip
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig.ShouldNotBeNull();
+		step.ProducerConfig!.CompressionType.ShouldBe(CompressionType.Gzip);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support Snappy compression")]
+	public void WithProducerConfig_Should_Support_Snappy_Compression()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			CompressionType = CompressionType.Snappy
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.CompressionType.ShouldBe(CompressionType.Snappy);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support Lz4 compression")]
+	public void WithProducerConfig_Should_Support_Lz4_Compression()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			CompressionType = CompressionType.Lz4
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.CompressionType.ShouldBe(CompressionType.Lz4);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support Zstd compression")]
+	public void WithProducerConfig_Should_Support_Zstd_Compression()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			CompressionType = CompressionType.Zstd
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.CompressionType.ShouldBe(CompressionType.Zstd);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support no compression")]
+	public void WithProducerConfig_Should_Support_No_Compression()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			CompressionType = CompressionType.None
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.CompressionType.ShouldBe(CompressionType.None);
+	}
+
+	#endregion
+
+	#region ProducerConfig - ACKs Tests
+
+	[Fact(DisplayName = "WithProducerConfig should support Acks.None")]
+	public void WithProducerConfig_Should_Support_Acks_None()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			Acks = Acks.None
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.Acks.ShouldBe(Acks.None);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support Acks.Leader")]
+	public void WithProducerConfig_Should_Support_Acks_Leader()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			Acks = Acks.Leader
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.Acks.ShouldBe(Acks.Leader);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support Acks.All")]
+	public void WithProducerConfig_Should_Support_Acks_All()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			Acks = Acks.All
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.Acks.ShouldBe(Acks.All);
+	}
+
+	#endregion
+
+	#region ProducerConfig - Batch and Buffer Tests
+
+	[Fact(DisplayName = "WithProducerConfig should support custom batch size")]
+	public void WithProducerConfig_Should_Support_Custom_Batch_Size()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			BatchSize = 32768 // 32KB
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.BatchSize.ShouldBe(32768);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support custom linger ms")]
+	public void WithProducerConfig_Should_Support_Custom_Linger_Ms()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			LingerMs = 10
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.LingerMs.ShouldBe(10);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support custom buffer memory")]
+	public void WithProducerConfig_Should_Support_Custom_Buffer_Memory()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			// BufferMemory would be configured here if available in ProducerConfig
+			MessageMaxBytes = 1048576 // 1MB
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.MessageMaxBytes.ShouldBe(1048576);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support custom max in flight requests")]
+	public void WithProducerConfig_Should_Support_Max_In_Flight_Requests()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			MaxInFlight = 5
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.MaxInFlight.ShouldBe(5);
+	}
+
+	#endregion
+
+	#region ProducerConfig - Retry and Timeout Tests
+
+	[Fact(DisplayName = "WithProducerConfig should support custom retry backoff")]
+	public void WithProducerConfig_Should_Support_Custom_Retry_Backoff()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			RetryBackoffMs = 500
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.RetryBackoffMs.ShouldBe(500);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support custom request timeout")]
+	public void WithProducerConfig_Should_Support_Custom_Request_Timeout()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			RequestTimeoutMs = 60000 // 60 seconds
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.RequestTimeoutMs.ShouldBe(60000);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support custom message timeout")]
+	public void WithProducerConfig_Should_Support_Custom_Message_Timeout()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			MessageTimeoutMs = 120000 // 2 minutes
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.MessageTimeoutMs.ShouldBe(120000);
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support enabling idempotence")]
+	public void WithProducerConfig_Should_Support_Enabling_Idempotence()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			EnableIdempotence = true
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.EnableIdempotence.HasValue.ShouldBeTrue();
+		step.ProducerConfig.EnableIdempotence.Value.ShouldBeTrue();
+	}
+
+	#endregion
+
+	#region ProducerConfig - Client Configuration Tests
+
+	[Fact(DisplayName = "WithProducerConfig should support custom client id")]
+	public void WithProducerConfig_Should_Support_Custom_Client_Id()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			ClientId = "my-custom-producer-client"
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.ClientId.ShouldBe("my-custom-producer-client");
+	}
+
+	[Fact(DisplayName = "WithProducerConfig should support multiple bootstrap servers")]
+	public void WithProducerConfig_Should_Support_Multiple_Bootstrap_Servers()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "broker1:9092,broker2:9092,broker3:9092"
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce("test-value")
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig!.BootstrapServers.ShouldBe("broker1:9092,broker2:9092,broker3:9092");
+	}
+
+	#endregion
+
+	#region JsonOptions - Naming Policy Tests
+
+	[Fact(DisplayName = "WithJsonOptions should support CamelCase naming policy")]
+	public void WithJsonOptions_Should_Support_CamelCase_Naming_Policy()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { FirstName = "John", LastName = "Doe" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions.ShouldNotBeNull();
+		step.JsonOptions!.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.CamelCase);
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should support SnakeCaseLower naming policy")]
+	public void WithJsonOptions_Should_Support_SnakeCaseLower_Naming_Policy()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { FirstName = "John", LastName = "Doe" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.SnakeCaseLower);
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should support SnakeCaseUpper naming policy")]
+	public void WithJsonOptions_Should_Support_SnakeCaseUpper_Naming_Policy()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseUpper
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { FirstName = "John", LastName = "Doe" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.SnakeCaseUpper);
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should support KebabCaseLower naming policy")]
+	public void WithJsonOptions_Should_Support_KebabCaseLower_Naming_Policy()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.KebabCaseLower
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { FirstName = "John", LastName = "Doe" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.KebabCaseLower);
+	}
+
+	#endregion
+
+	#region JsonOptions - Serialization Behavior Tests
+
+	[Fact(DisplayName = "WithJsonOptions should support WriteIndented option")]
+	public void WithJsonOptions_Should_Support_WriteIndented_Option()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			WriteIndented = true
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { Name = "Test" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.WriteIndented.ShouldBeTrue();
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should support DefaultIgnoreCondition")]
+	public void WithJsonOptions_Should_Support_DefaultIgnoreCondition()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { Name = "Test", Description = (string?)null })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.DefaultIgnoreCondition.ShouldBe(JsonIgnoreCondition.WhenWritingNull);
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should support PropertyNameCaseInsensitive")]
+	public void WithJsonOptions_Should_Support_PropertyNameCaseInsensitive()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			PropertyNameCaseInsensitive = true
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { Name = "Test" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.PropertyNameCaseInsensitive.ShouldBeTrue();
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should support AllowTrailingCommas")]
+	public void WithJsonOptions_Should_Support_AllowTrailingCommas()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			AllowTrailingCommas = true
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { Name = "Test" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.AllowTrailingCommas.ShouldBeTrue();
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should support MaxDepth configuration")]
+	public void WithJsonOptions_Should_Support_MaxDepth_Configuration()
+	{
+		// Arrange
+		var options = new JsonSerializerOptions
+		{
+			MaxDepth = 64
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Produce(new { Name = "Test" })
+			.WithJsonOptions(options);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions!.MaxDepth.ShouldBe(64);
+	}
+
+	#endregion
+
+	#region Complex Configuration Integration Tests
+
+	[Fact(DisplayName = "Should support complete ProducerConfig for high-throughput scenario")]
+	public void Should_Support_Complete_ProducerConfig_For_High_Throughput()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "broker1:9092,broker2:9092,broker3:9092",
+			ClientId = "high-throughput-producer",
+			Acks = Acks.Leader,
+			CompressionType = CompressionType.Lz4,
+			BatchSize = 65536, // 64KB
+			LingerMs = 10,
+			MaxInFlight = 5,
+			EnableIdempotence = false
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("high-volume-topic")
+			.Produce(new { EventId = Guid.NewGuid(), Data = "test" })
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig.ShouldNotBeNull();
+		step.ProducerConfig!.Acks.ShouldBe(Acks.Leader);
+		step.ProducerConfig.CompressionType.ShouldBe(CompressionType.Lz4);
+		step.ProducerConfig.BatchSize.ShouldBe(65536);
+		step.ProducerConfig.LingerMs.ShouldBe(10);
+		step.ProducerConfig.MaxInFlight.ShouldBe(5);
+		step.ProducerConfig.EnableIdempotence.ShouldBe(false);
+	}
+
+	[Fact(DisplayName = "Should support complete ProducerConfig for reliability scenario")]
+	public void Should_Support_Complete_ProducerConfig_For_Reliability()
+	{
+		// Arrange
+		var config = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			ClientId = "reliable-producer",
+			Acks = Acks.All,
+			EnableIdempotence = true,
+			MaxInFlight = 1,
+			RetryBackoffMs = 1000,
+			RequestTimeoutMs = 30000,
+			MessageTimeoutMs = 60000
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("critical-topic")
+			.Produce(new { TransactionId = "TXN-123", Amount = 1000.00m })
+			.WithProducerConfig(config);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig.ShouldNotBeNull();
+		step.ProducerConfig!.Acks.ShouldBe(Acks.All);
+		step.ProducerConfig.EnableIdempotence.ShouldBe(true);
+		step.ProducerConfig.MaxInFlight.ShouldBe(1);
+	}
+
+	[Fact(DisplayName = "Should support complete JsonOptions for API integration")]
+	public void Should_Support_Complete_JsonOptions_For_API_Integration()
+	{
+		// Arrange
+		var jsonOptions = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+			DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+			WriteIndented = false,
+			PropertyNameCaseInsensitive = true,
+			MaxDepth = 32
+		};
+
+		var apiPayload = new
+		{
+			ApiVersion = "v1",
+			Timestamp = DateTime.UtcNow,
+			Data = new
+			{
+				UserId = "user-123",
+				Action = "CREATE",
+				Resource = "Order",
+				Metadata = new Dictionary<string, object>
+				{
+					["client_ip"] = "192.168.1.1",
+					["user_agent"] = "Mozilla/5.0"
+				}
+			}
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("api-events")
+			.Produce(apiPayload)
+			.WithJsonOptions(jsonOptions);
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.JsonOptions.ShouldNotBeNull();
+		step.JsonOptions!.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.CamelCase);
+		step.JsonOptions.DefaultIgnoreCondition.ShouldBe(JsonIgnoreCondition.WhenWritingNull);
+		step.JsonOptions.PropertyNameCaseInsensitive.ShouldBeTrue();
+	}
+
+	[Fact(DisplayName = "Should combine ProducerConfig and JsonOptions in single chain")]
+	public void Should_Combine_ProducerConfig_And_JsonOptions_In_Single_Chain()
+	{
+		// Arrange
+		var producerConfig = new ProducerConfig
+		{
+			BootstrapServers = "kafka:9092",
+			CompressionType = CompressionType.Gzip,
+			Acks = Acks.All
+		};
+
+		var jsonOptions = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+			WriteIndented = true
+		};
+
+		// Act
+		var scenario = Given()
+			.Topic("combined-config-topic")
+			.Produce(new { OrderId = "123", Status = "PENDING" })
+			.WithProducerConfig(producerConfig)
+			.WithJsonOptions(jsonOptions)
+			.WithTimeout(TimeSpan.FromSeconds(45))
+			.WithKey("order-123")
+			.WithHeader("schema-version", Encoding.UTF8.GetBytes("v2"));
+
+		// Assert
+		var step = (KafkaProduceStep)scenario.CurrentStep;
+		step.ProducerConfig.ShouldNotBeNull();
+		step.ProducerConfig!.CompressionType.ShouldBe(CompressionType.Gzip);
+		step.JsonOptions.ShouldNotBeNull();
+		step.JsonOptions!.PropertyNamingPolicy.ShouldBe(JsonNamingPolicy.SnakeCaseLower);
+		step.Timeout.ShouldBe(TimeSpan.FromSeconds(45));
+		step.Key.ShouldBe("order-123");
+		step.Headers.ShouldNotBeNull();
+	}
+
+	#endregion
+
+	#region ProducerConfig Immutability Tests
+
+	[Fact(DisplayName = "WithProducerConfig should maintain immutability")]
+	public void WithProducerConfig_Should_Maintain_Immutability()
+	{
+		// Arrange
+		var config1 = new ProducerConfig { BootstrapServers = "kafka1:9092" };
+		var config2 = new ProducerConfig { BootstrapServers = "kafka2:9092" };
+
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var originalStep = scenario.CurrentStep;
+
+		// Act
+		scenario
+			.WithProducerConfig(config1)
+			.WithProducerConfig(config2);
+
+		var finalStep = scenario.CurrentStep;
+
+		// Assert
+		originalStep.ShouldNotBe(finalStep);
+		((KafkaProduceStep)finalStep).ProducerConfig.ShouldBe(config2);
+	}
+
+	[Fact(DisplayName = "WithJsonOptions should maintain immutability")]
+	public void WithJsonOptions_Should_Maintain_Immutability()
+	{
+		// Arrange
+		var options1 = new JsonSerializerOptions { WriteIndented = true };
+		var options2 = new JsonSerializerOptions { WriteIndented = false };
+
+		var scenario = Given().Topic("test-topic").Produce("test-value");
+		var originalStep = scenario.CurrentStep;
+
+		// Act
+		scenario
+			.WithJsonOptions(options1)
+			.WithJsonOptions(options2);
+
+		var finalStep = scenario.CurrentStep;
+
+		// Assert
+		originalStep.ShouldNotBe(finalStep);
+		((KafkaProduceStep)finalStep).JsonOptions.ShouldBe(options2);
+	}
+
+	#endregion
+}

--- a/src/XUnitAssured.Tests/KafkaTests/SaslPlainAuthTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/SaslPlainAuthTests.cs
@@ -1,5 +1,6 @@
 using XUnitAssured.Kafka.Configuration;
 using XUnitAssured.Kafka.Extensions;
+using XUnitAssured.Kafka.Steps;
 using Xunit;
 using Shouldly;
 
@@ -18,8 +19,8 @@ public class SaslPlainAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithSaslPlain("username", "password")
-			.Consume();
+			.Consume()
+			.WithSaslPlain("username", "password");
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -32,8 +33,8 @@ public class SaslPlainAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithSaslPlain("username", "password", useSsl: false)
-			.Consume();
+			.Consume()
+			.WithSaslPlain("username", "password", useSsl: false);
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -45,11 +46,11 @@ public class SaslPlainAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
+			.Consume()
 			.WithKafkaAuth(config =>
 			{
 				config.UseSaslPlain("username", "password");
-			})
-			.Consume();
+			});
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -61,8 +62,8 @@ public class SaslPlainAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithNoKafkaAuth()
-			.Consume();
+			.Consume()
+			.WithNoKafkaAuth();
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -109,6 +110,21 @@ public class SaslPlainAuthTests
 			scenario.WithSaslPlain("user", "pass"));
 	}
 
+	[Fact(DisplayName = "Should configure SASL/PLAIN authentication after Topic is set")]
+	public void Should_Configure_SaslPlain_After_Topic()
+	{
+		// Arrange & Act
+		var scenario = Given()
+			.Topic("test-topic")
+			.Consume()
+			.WithSaslPlain("username", "password");
+
+		// Assert
+		scenario.ShouldNotBeNull();
+		scenario.CurrentStep.ShouldNotBeNull();
+		scenario.CurrentStep.ShouldBeOfType<KafkaConsumeStep>();
+	}
+
 	[Fact(Skip = "Integration test - requires Kafka broker with SASL/PLAIN", DisplayName = "Integration test should connect to Kafka with SASL/PLAIN authentication")]
 	public void Integration_Should_Connect_With_SaslPlain()
 	{
@@ -119,9 +135,9 @@ public class SaslPlainAuthTests
 		{
 			Given()
 				.Topic("test-topic")
+				.Consume()
 				.WithBootstrapServers("pkc-xxxxx.us-east-1.aws.confluent.cloud:9092")
 				.WithSaslPlain(username, password)
-				.Consume()
 				.Validate(result =>
 				{
 					result.Success.ShouldBeTrue();
@@ -129,3 +145,4 @@ public class SaslPlainAuthTests
 		}
 	}
 }
+

--- a/src/XUnitAssured.Tests/KafkaTests/SaslScramAuthTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/SaslScramAuthTests.cs
@@ -19,8 +19,8 @@ public class SaslScramAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithSaslScram256("username", "password")
-			.Consume();
+			.Consume()
+			.WithSaslScram256("username", "password");
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -33,8 +33,8 @@ public class SaslScramAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithSaslScram512("username", "password")
-			.Consume();
+			.Consume()
+			.WithSaslScram512("username", "password");
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -46,8 +46,8 @@ public class SaslScramAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithSaslScram256("username", "password", useSsl: false)
-			.Consume();
+			.Consume()
+			.WithSaslScram256("username", "password", useSsl: false);
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -59,11 +59,11 @@ public class SaslScramAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
+			.Consume()
 			.WithKafkaAuth(config =>
 			{
 				config.UseSaslScram256("username", "password");
-			})
-			.Consume();
+			});
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -138,9 +138,9 @@ public class SaslScramAuthTests
 		{
 			Given()
 				.Topic("test-topic")
+				.Consume()
 				.WithBootstrapServers(bootstrapServers)
 				.WithSaslScram256(username, password)
-				.Consume()
 				.Validate(result =>
 				{
 					result.Success.ShouldBeTrue();
@@ -158,8 +158,8 @@ public class SaslScramAuthTests
 		{
 			Given()
 				.Topic("test-topic")
-				.WithSaslScram512(username, password)
 				.Consume()
+				.WithSaslScram512(username, password)
 				.Validate(result =>
 				{
 					result.Success.ShouldBeTrue();
@@ -167,3 +167,4 @@ public class SaslScramAuthTests
 		}
 	}
 }
+

--- a/src/XUnitAssured.Tests/KafkaTests/SslAuthTests.cs
+++ b/src/XUnitAssured.Tests/KafkaTests/SslAuthTests.cs
@@ -18,8 +18,8 @@ public class SslAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithSsl("/path/to/ca-cert.pem")
-			.Consume();
+			.Consume()
+			.WithSsl("/path/to/ca-cert.pem");
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -32,8 +32,8 @@ public class SslAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
-			.WithSsl("/path/to/ca-cert.pem", enableCertificateVerification: false)
-			.Consume();
+			.Consume()
+			.WithSsl("/path/to/ca-cert.pem", enableCertificateVerification: false);
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -45,11 +45,11 @@ public class SslAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
+			.Consume()
 			.WithMutualTls(
 				certificateLocation: "/path/to/client-cert.pem",
 				keyLocation: "/path/to/client-key.pem"
-			)
-			.Consume();
+			);
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -61,13 +61,13 @@ public class SslAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
+			.Consume()
 			.WithMutualTls(
 				certificateLocation: "/path/to/client-cert.pem",
 				keyLocation: "/path/to/client-key.pem",
 				caLocation: "/path/to/ca-cert.pem",
 				keyPassword: "password123"
-			)
-			.Consume();
+			);
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -79,11 +79,11 @@ public class SslAuthTests
 		// Arrange & Act
 		var scenario = Given()
 			.Topic("test-topic")
+			.Consume()
 			.WithKafkaAuth(config =>
 			{
 				config.UseSsl("/path/to/ca-cert.pem");
-			})
-			.Consume();
+			});
 
 		// Assert
 		scenario.ShouldNotBeNull();
@@ -155,9 +155,9 @@ public class SslAuthTests
 		{
 			Given()
 				.Topic("test-topic")
+				.Consume()
 				.WithBootstrapServers(bootstrapServers)
 				.WithSsl(caLocation)
-				.Consume()
 				.Validate(result =>
 				{
 					result.Success.ShouldBeTrue();
@@ -176,8 +176,8 @@ public class SslAuthTests
 		{
 			Given()
 				.Topic("test-topic")
-				.WithMutualTls(clientCert, clientKey, caCert)
 				.Consume()
+				.WithMutualTls(clientCert, clientKey, caCert)
 				.Validate(result =>
 				{
 					result.Success.ShouldBeTrue();
@@ -185,3 +185,4 @@ public class SslAuthTests
 		}
 	}
 }
+


### PR DESCRIPTION
Inclui KafkaProduceStep, métodos .Produce(), .WithKey(), .WithHeaders(), .WithPartition(), .WithProducerConfig(), .WithJsonOptions() e validações específicas de produção. Refatora autenticação para suportar produção e consumo. Expande testes unitários para produção, configuração avançada e validação. Garante imutabilidade dos passos e documentação XML no DSL.